### PR TITLE
Hopefully fix another router issue

### DIFF
--- a/src/Powercord/coremods/router/index.js
+++ b/src/Powercord/coremods/router/index.js
@@ -55,9 +55,9 @@ async function injectSidebar () {
 
 async function forceRouterUpdate () {
   // Views
-  const { app } = getAllModules([ 'app' ]).find(m => Object.keys(m).length === 1);
+  const { app } = getAllModules([ 'app' ]).find(m => Object.keys(m).length === 2);
   const viewsInstance = getOwnerInstance(await waitFor(`.${app}`));
-  findInTree(viewsInstance._reactInternals || viewsInstance._reactInternalFiber, n => n && n.historyUnlisten, { walkable: [ 'child', 'stateNode' ] }).forceUpdate();
+  viewsInstance.forceUpdate();
 
   // Routes
   const { container } = await getModule([ 'container', 'downloadProgressCircle' ]);


### PR DESCRIPTION
Not entirely sure about the semantics of that old `findByTree` usage, it was supposed to `forceUpdate` something far down the tree but the prop it searched for has vanished and so I have no way of knowing what it was trying to find.