### PR TITLE
Context crash fix

### DIFF
--- a/src/fake_node_modules/powercord/util/injectContextMenu.js
+++ b/src/fake_node_modules/powercord/util/injectContextMenu.js
@@ -64,7 +64,7 @@ async function injectContextMenu (injectionId, displayName, fn, pre = false) {
 
             const analytics = wrapInHooks(ctx.type)(ctx.props).props.children;
             const children = wrapInHooks(analytics.type)(analytics.props);
-            if (children.props.children.type?.displayName === displayName) {
+            if (children.props.children?.type?.displayName === displayName) {
               patched = true;
               uninject(injectionId);
 

--- a/src/fake_node_modules/powercord/util/injectContextMenu.js
+++ b/src/fake_node_modules/powercord/util/injectContextMenu.js
@@ -64,7 +64,7 @@ async function injectContextMenu (injectionId, displayName, fn, pre = false) {
 
             const analytics = wrapInHooks(ctx.type)(ctx.props).props.children;
             const children = wrapInHooks(analytics.type)(analytics.props);
-            if (children.props.children.type.displayName === displayName) {
+            if (children.props.children.type?.displayName === displayName) {
               patched = true;
               uninject(injectionId);
 


### PR DESCRIPTION
Fixes `injectContextMenu` crash if children is an array or not defined. #33