### PR TITLE
make dividers function the way they're meant to

### DIFF
--- a/src/fake_node_modules/powercord/components/Divider.jsx
+++ b/src/fake_node_modules/powercord/components/Divider.jsx
@@ -1,3 +1,6 @@
-const { React } = require('powercord/webpack');
+const { React, getModule, getModuleByDisplayName } = require('powercord/webpack');
 
-module.exports = React.memo(() => <div className='divider-3LgWDL dividerDefault-3C2-ws'/>);
+const Divider = getModuleByDisplayName('FormDivider', false);
+const Classes = getModule(['dividerDefault'], false);
+
+module.exports = React.memo(() => <Divider className={Classes.dividerDefault} />)


### PR DESCRIPTION
Before (broken due to hardcoded classes): 

![image](https://user-images.githubusercontent.com/98427312/182038194-77e94f3c-3f50-415d-9e2c-41bf8c2cfef1.png)

After:

![image](https://user-images.githubusercontent.com/98427312/182038223-76fd34f5-2527-4bfb-b019-3259195c8e7a.png)
