### PR TITLE
add some utilities for forcing chunk lazyloading

### DIFF
--- a/src/fake_node_modules/powercord/webpack/old.webpack.js
+++ b/src/fake_node_modules/powercord/webpack/old.webpack.js
@@ -95,7 +95,7 @@ const webpack = {
   * @returns {ModuleInfo} The module info.
   */
   getModuleInfoByDisplayName (displayName) {
-    return Object.values(webpack.instance.cache).find(m => m?.exports?.displayName === displayName || m?.exports?.default?.displayName === displayName)
+    return Object.values(webpack.instance.cache).find(m => m?.exports?.displayName === displayName || m?.exports?.default?.displayName === displayName);
   },
 
   /**
@@ -104,7 +104,7 @@ const webpack = {
   * @returns {Chunk} The chunk.
   */
   getChunkByModuleId (id) {
-    return webpackChunkdiscord_app.find(m => id in m[1])
+    return webpackChunkdiscord_app.find(m => id in m[1]);
   },
 
   /**
@@ -113,8 +113,8 @@ const webpack = {
   * @returns {function} The source function.
   */
   getModuleSourceById (id) {
-    const chunk = webpack.getChunkByModuleId(id)
-    return chunk[1][id]
+    const chunk = webpack.getChunkByModuleId(id);
+    return chunk[1][id];
   },
 
   /**
@@ -123,15 +123,17 @@ const webpack = {
   * @returns {number[]} The 'to be lazy-loaded' chunk ids
   */
   getLazyLoadedChunkIdsByModuleId (id) {
-    const srcStr = webpack.getModuleSourceById(id).toString()
-    const requireArgument = srcStr.toString().match(/^\(.,.,(.)\)/)?.[1]
+    const srcStr = webpack.getModuleSourceById(id).toString();
+    const requireArgument = srcStr.toString().match(/^\(.,.,(.)\)/)?.[1];
 
-    if (!requireArgument) return []
+    if (!requireArgument) {
+      return [];
+    }
 
-    const importPattern = new RegExp(`\\b${requireArgument}\\.e\\(\\d+\\)`, 'g')
-    const imports = srcStr.toString().match(importPattern)
-    const ids = imports.map(e => e.slice(4, -1))
-    return ids
+    const importPattern = new RegExp(`\\b${requireArgument}\\.e\\(\\d+\\)`, 'g');
+    const imports = srcStr.toString().match(importPattern);
+    const ids = imports.map(e => e.slice(4, -1));
+    return ids;
   },
 
 
@@ -156,15 +158,13 @@ const webpack = {
         webpack.instance.cache = r.c;
         webpack.instance.require = (m) => r(m);
 
-        webpack.instance.loadChunk = (c) => {
-          return r.e(c)
+        webpack.instance.loadChunk = (c) => r.e(c)
           .then(() => {
             // Get chunk
-            const chunk = webpackChunkdiscord_app.find(C => C[0][0] == c)
+            const chunk = webpackChunkdiscord_app.find(C => `${C[0][0]}` === c);
             // Cache all the modules
-            Object.keys(chunk[1]).forEach(m => r(m))
-          })
-        };
+            Object.keys(chunk[1]).forEach(m => r(m));
+          });
       }
     ]);
 

--- a/src/fake_node_modules/powercord/webpack/old.webpack.js
+++ b/src/fake_node_modules/powercord/webpack/old.webpack.js
@@ -4,13 +4,29 @@ const moduleFilters = require('./modules.json');
 /**
 * @typedef WebpackInstance
 * @property {object} cache
+* @property {object} chunkHashMap
 * @property {function} require
+* @property {function} loadChunk
 */
 
 /**
 * @typedef ContextMenuModule
 * @property {function} openContextMenu
 * @property {function} closeContextMenu
+*/
+
+
+/**
+ * @typedef ModuleInfo
+ * @property {number} id The module's ids.
+ * @property {boolean} loaded Whether the module is loaded
+ * @property {object} exports The module's exports
+ */
+
+/**
+* @typedef {number[]} chunkIds The chunk's ids.
+* @typedef {object.<number, function>} chunkMdls A map of module ids to module source functions.
+* @typedef {[chunkIds, chunkMdls]} Chunk
 */
 
 /**
@@ -75,6 +91,52 @@ const webpack = {
   },
 
   /**
+  * Grabs a React component's module info by its display name
+  * @param {string} displayName Component's display name.
+  * @returns {ModuleInfo} The module info.
+  */
+  getModuleInfoByDisplayName (displayName) {
+    return Object.values(webpack.instance.cache).find(m => m?.exports?.displayName === displayName || m?.exports?.default?.displayName === displayName)
+  },
+
+  /**
+  * Grabs a chunk by one of its modules' id
+  * @param {number} id The module id.
+  * @returns {Chunk} The chunk.
+  */
+  getChunkByModuleId (id) {
+    return webpackChunkdiscord_app.find(m => id in m[1])
+  },
+
+  /**
+  * Gets the source function of a module by its id
+  * @param {number} id The module id.
+  * @returns {function} The source function.
+  */
+  getModuleSourceById (id) {
+    const chunk = webpack.getChunkByModuleId(id)
+    return chunk[1][id]
+  },
+
+  /**
+  * From a given module id, gets a list of chunk ids that said module might lazy load.
+  * @param {number} id The module id.
+  * @returns {number[]} The 'to be lazy-loaded' chunk ids
+  */
+  getLazyLoadedChunkIdsByModuleId (id) {
+    const srcStr = webpack.getModuleSourceById(id).toString()
+    const requireArgument = srcStr.toString().match(/^\(.,.,(.)\)/)?.[1]
+
+    if (!requireArgument) return []
+
+    const importPattern = new RegExp(`\\b${requireArgument}\\.e\\(\\d+\\)`, 'g')
+    const imports = srcStr.toString().match(importPattern)
+    const ids = imports.map(e => e.slice(4, -1))
+    return ids
+  },
+
+
+  /**
   * Initializes the injection into Webpack
   * @returns {Promise<void>}
   */
@@ -94,6 +156,16 @@ const webpack = {
       (r) => {
         webpack.instance.cache = r.c;
         webpack.instance.require = (m) => r(m);
+
+        webpack.instance.loadChunk = (c) => {
+          return r.e(c)
+          .then(() => {
+            // Get chunk
+            const chunk = webpackChunkdiscord_app.find(C => C[0][0] == c)
+            // Cache all the modules
+            Object.keys(chunk[1]).forEach(m => r(m))
+          })
+        };
       }
     ]);
 

--- a/src/fake_node_modules/powercord/webpack/old.webpack.js
+++ b/src/fake_node_modules/powercord/webpack/old.webpack.js
@@ -4,7 +4,6 @@ const moduleFilters = require('./modules.json');
 /**
 * @typedef WebpackInstance
 * @property {object} cache
-* @property {object} chunkHashMap
 * @property {function} require
 * @property {function} loadChunk
 */

--- a/src/fake_node_modules/powercord/webpack/old.webpack.js
+++ b/src/fake_node_modules/powercord/webpack/old.webpack.js
@@ -17,7 +17,7 @@ const moduleFilters = require('./modules.json');
 
 /**
  * @typedef ModuleInfo
- * @property {number} id The module's ids.
+ * @property {number} id The module's id.
  * @property {boolean} loaded Whether the module is loaded
  * @property {object} exports The module's exports
  */


### PR DESCRIPTION
My use case:

`FileUploadInput.jsx`
```jsx
const { React, getModuleByDisplayName, getModuleInfoByDisplayName, getLazyLoadedChunkIdsByModuleId, instance } = require('powercord/webpack')
const { AsyncComponent, settings: { FormItem } } = require('powercord/components')

const [, STICKER_MODAL_CHUNK_ID ] = getLazyLoadedChunkIdsByModuleId(getModuleInfoByDisplayName('GuildStickersTiers').id)

const Input = AsyncComponent.from(instance.loadChunk(STICKER_MODAL_CHUNK_ID).then(() => {
  return getModuleByDisplayName('FileUploadInput')
}))

module.exports = class TextInput extends React.PureComponent {
  render () {
    const { children: title, note, required } = this.props
    delete this.props.children

    return (
      <FormItem title={title} note={note} required={required} noteHasMargin>
        <Input {...this.props} />
      </FormItem>
    )
  }
}
```

That component above in use:
```jsx
<FileUploadInput
  buttonText="Browse"
  filename=""
  filters={[]}
  onFileSelect={(...args) => console.log('File Select:', args)}
  placeholder="Choose file"
>
  Editor Program
</FileUploadInput>
```
![image](https://user-images.githubusercontent.com/20448879/182573379-7cbb57ce-463a-4c91-9069-543c4d77f7ae.png)

