### PR TITLE
feat: lazy webpack

### DIFF
--- a/src/fake_node_modules/powercord/webpack/lazy.js
+++ b/src/fake_node_modules/powercord/webpack/lazy.js
@@ -1,0 +1,100 @@
+const listeners = new Map();
+let originalPush;
+
+// lazily required since otherwise we have a circular dependency (index -> old.webpack -> lazy -> index)
+let pcWebpack;
+
+function onPush(chunk) {
+  const modules = chunk[1];
+
+  for (const id in modules) {
+    const mod = modules[id];
+    modules[id] = function (module, exports, require) {
+      try {
+        mod(module, exports, require);
+      } catch (error) {
+        console.error("Error while loading webpack chunk", error);
+        return;
+      }
+      for (const [filter, callback] of listeners) {
+        try {
+          if (filter(exports)) {
+            listeners.delete(filter);
+            callback(exports);
+          } else if (exports.default && filter(exports.default)) {
+            listeners.delete(filter);
+            callback(exports.default);
+          }
+        } catch (error) {
+          console.error("Error while firing callback for webpack chunk", error);
+        }
+      }
+    }
+  }
+
+  return originalPush.call(webpackChunkdiscord_app, chunk);
+}
+
+/**
+ * Do not use or you will be slapped
+ */
+function _patchPush() {
+  originalPush = webpackChunkdiscord_app.push;
+  Object.defineProperty(webpackChunkdiscord_app, "push", {
+    get: () => onPush,
+    set: (v) => originalPush = v,
+    enumerable: true
+  });
+}
+
+/**
+ * Subscribe to webpack to listen for lazily added modules
+ * @param {function|string[]} filter Filter function to test modules with
+ * @param {function} callback Callback to call once a module matches the filter. Receives
+ * the module's exports as argument.
+ */
+function subscribe(filter, callback) {
+  const wp = pcWebpack ?? (pcWebpack = require("."));
+  const existingMod = wp.getModule(filter, false);
+  if (existingMod) {
+    callback(existingMod);
+    return;
+  }
+
+  if (Array.isArray(filter)) {
+    const keys = filter;
+    filter = m => keys.every(key => m.hasOwnProperty(key) || (m.__proto__ && m.__proto__.hasOwnProperty(key)));
+  } else if (typeof filter !== "function") {
+    throw new Error("filter must be an array or function, got " + typeof filter);
+  }
+
+  if (typeof callback !== "function") {
+    throw new Error("callback must be a function, got " + typeof filter);
+  }
+
+  listeners.set(filter, callback);
+}
+
+/**
+ * Asynchronously wait for a module, useful for retrieving lazily loaded modules
+ * 
+ * Please note that unlike getModule, this will never return null. If your filter matches no module,
+ * the promise will simply never resolve.
+ * @param {function|string[]} filter Module filter 
+ * @returns Promise<Module>
+ */
+function waitFor(filter) {
+  return new Promise((resolve, reject) => {
+    try {
+      subscribe(filter, resolve);
+    } catch (err) {
+      reject(err);
+    }
+  });
+}
+
+module.exports = {
+  _patchPush,
+  subscribe,
+  waitFor
+};

--- a/src/fake_node_modules/powercord/webpack/lazy.js
+++ b/src/fake_node_modules/powercord/webpack/lazy.js
@@ -1,10 +1,11 @@
+/* eslint-disable callback-return */
 const listeners = new Map();
 let originalPush;
 
 // lazily required since otherwise we have a circular dependency (index -> old.webpack -> lazy -> index)
 let pcWebpack;
 
-function onPush(chunk) {
+function onPush (chunk) {
   const modules = chunk[1];
 
   for (const id in modules) {
@@ -13,10 +14,10 @@ function onPush(chunk) {
       try {
         mod(module, exports, require);
       } catch (error) {
-        console.error("Error while loading webpack chunk", error);
+        console.error('Error while loading webpack chunk', error);
         return;
       }
-      for (const [filter, callback] of listeners) {
+      for (const [ filter, callback ] of listeners) {
         try {
           if (filter(exports)) {
             listeners.delete(filter);
@@ -26,10 +27,10 @@ function onPush(chunk) {
             callback(exports.default);
           }
         } catch (error) {
-          console.error("Error while firing callback for webpack chunk", error);
+          console.error('Error while firing callback for webpack chunk', error);
         }
       }
-    }
+    };
   }
 
   return originalPush.call(webpackChunkdiscord_app, chunk);
@@ -38,9 +39,9 @@ function onPush(chunk) {
 /**
  * Do not use or you will be slapped
  */
-function _patchPush() {
+function _patchPush () {
   originalPush = webpackChunkdiscord_app.push;
-  Object.defineProperty(webpackChunkdiscord_app, "push", {
+  Object.defineProperty(webpackChunkdiscord_app, 'push', {
     get: () => onPush,
     set: (v) => originalPush = v,
     enumerable: true
@@ -53,8 +54,8 @@ function _patchPush() {
  * @param {function} callback Callback to call once a module matches the filter. Receives
  * the module's exports as argument.
  */
-function subscribe(filter, callback) {
-  const wp = pcWebpack ?? (pcWebpack = require("."));
+function subscribe (filter, callback) {
+  const wp = pcWebpack ?? (pcWebpack = require('.'));
   const existingMod = wp.getModule(filter, false);
   if (existingMod) {
     callback(existingMod);
@@ -64,12 +65,12 @@ function subscribe(filter, callback) {
   if (Array.isArray(filter)) {
     const keys = filter;
     filter = m => keys.every(key => m.hasOwnProperty(key) || (m.__proto__ && m.__proto__.hasOwnProperty(key)));
-  } else if (typeof filter !== "function") {
-    throw new Error("filter must be an array or function, got " + typeof filter);
+  } else if (typeof filter !== 'function') {
+    throw new Error(`filter must be an array or function, got ${typeof filter}`);
   }
 
-  if (typeof callback !== "function") {
-    throw new Error("callback must be a function, got " + typeof filter);
+  if (typeof callback !== 'function') {
+    throw new Error(`callback must be a function, got ${typeof filter}`);
   }
 
   listeners.set(filter, callback);
@@ -77,13 +78,13 @@ function subscribe(filter, callback) {
 
 /**
  * Asynchronously wait for a module, useful for retrieving lazily loaded modules
- * 
+ *
  * Please note that unlike getModule, this will never return null. If your filter matches no module,
  * the promise will simply never resolve.
- * @param {function|string[]} filter Module filter 
+ * @param {function|string[]} filter Module filter
  * @returns Promise<Module>
  */
-function waitFor(filter) {
+function waitFor (filter) {
   return new Promise((resolve, reject) => {
     try {
       subscribe(filter, resolve);

--- a/src/fake_node_modules/powercord/webpack/lazy.js
+++ b/src/fake_node_modules/powercord/webpack/lazy.js
@@ -14,8 +14,9 @@ function onPush (chunk) {
       try {
         mod(module, exports, require);
       } catch (error) {
-        console.error('Error while loading webpack chunk', error);
-        return;
+        console.error('Error while loading webpack chunk. Rethrowing', error);
+        // Since the original function threw, best to rethrow to not alter behaviour
+        throw error;
       }
       for (const [ filter, callback ] of listeners) {
         try {

--- a/src/fake_node_modules/powercord/webpack/old.webpack.js
+++ b/src/fake_node_modules/powercord/webpack/old.webpack.js
@@ -18,6 +18,8 @@ const moduleFilters = require('./modules.json');
 * @property {WebpackInstance} instance
 */
 const webpack = {
+  ...require("./lazy"),
+
   /**
   * Grabs a module from the Webpack store
   * @param {function|string[]} filter Filter used to grab the module. Can be a function or an array of keys the object must have.
@@ -96,6 +98,11 @@ const webpack = {
         webpack.instance.require = (m) => r(m);
       }
     ]);
+    webpackChunkdiscord_app.pop();
+
+    // Patch push to enable webpack chunk listeners
+    webpack._patchPush();
+    delete webpack._patchPush;
 
     // Load modules pre-fetched
     for (const mdl in moduleFilters) {

--- a/src/fake_node_modules/powercord/webpack/old.webpack.js
+++ b/src/fake_node_modules/powercord/webpack/old.webpack.js
@@ -18,7 +18,7 @@ const moduleFilters = require('./modules.json');
 * @property {WebpackInstance} instance
 */
 const webpack = {
-  ...require("./lazy"),
+  ...require('./lazy'),
 
   /**
   * Grabs a module from the Webpack store


### PR DESCRIPTION
Adds two new methods to powercord/webpack: subscribe and waitFor

These allow you to asynchronously wait for lazily loaded webpack modules and immediately run a callback once they are loaded. In other words, this is useful for patching lazy context menus, lazy modals, etc

An example usage would be
```js
require("powercord/webpack").subscribe(
    m => m?.default?.displayName === "BanConfirm",
    m => {
        require("powercord/injector").inject("lazy-banconfirm-patch", m, "default", () => "trolley");
    }
)
```

