### PR TITLE
Fix module repo button for SSH git URLs

### DIFF
--- a/src/Powercord/plugins/pc-moduleManager/components/parts/BaseProduct.jsx
+++ b/src/Powercord/plugins/pc-moduleManager/components/parts/BaseProduct.jsx
@@ -109,7 +109,10 @@ class BaseProduct extends React.PureComponent {
       return await PowercordNative.exec('git remote get-url origin', {
         cwd: item,
         timeout: TIMEOUT
-      }).then((r) => r.stdout.toString());
+      }).then((r) => r.stdout.toString()
+        .replace(/.git$/, '')
+        .replace(/^git@(.+):/, 'https://$1/')
+      );
     } catch (e) {
       console.warn('Failed to fetch git origin url; ignoring.');
       return null;

--- a/src/Powercord/plugins/pc-moduleManager/components/parts/BaseProduct.jsx
+++ b/src/Powercord/plugins/pc-moduleManager/components/parts/BaseProduct.jsx
@@ -110,7 +110,7 @@ class BaseProduct extends React.PureComponent {
         cwd: item,
         timeout: TIMEOUT
       }).then((r) => r.stdout.toString()
-        .replace(/.git$/, '')
+        .replace(/\.git$/, '')
         .replace(/^git@(.+):/, 'https://$1/')
       );
     } catch (e) {


### PR DESCRIPTION
Plugins/themes using SSH Git URLs (`git@github.com:username/reponame.git`) would not work when pressing the "Repository" button. This PR fixes that.