### PR TITLE
Add IDs to product cards

### DIFF
--- a/src/Powercord/plugins/pc-moduleManager/components/parts/BaseProduct.jsx
+++ b/src/Powercord/plugins/pc-moduleManager/components/parts/BaseProduct.jsx
@@ -53,7 +53,7 @@ class BaseProduct extends React.PureComponent {
             look={Button.Looks.LINK}
             size={Button.Sizes.SMALL}
             color={Button.Colors.TRANSPARENT}
-            id="server-invite"
+            className='server-invite'
           > {Messages.REPLUGGED_PLUGINS_DISCORD}
           </Button>
           }
@@ -64,7 +64,7 @@ class BaseProduct extends React.PureComponent {
                 look={Button.Looks.LINK}
                 size={Button.Sizes.SMALL}
                 color={Button.Colors.TRANSPARENT}
-                id="website"
+                className='website'
               > {Messages.REPLUGGED_PLUGINS_WEBSITE}
               </Button>
           }
@@ -75,7 +75,7 @@ class BaseProduct extends React.PureComponent {
               look={Button.Looks.LINK}
               size={Button.Sizes.SMALL}
               color={Button.Colors.TRANSPARENT}
-              id="git-repo"
+              className='git-repo'
             > {Messages.REPLUGGED_PLUGINS_GITHUB}
             </Button>
           }
@@ -86,7 +86,7 @@ class BaseProduct extends React.PureComponent {
               look={Button.Looks.LINK}
               size={Button.Sizes.SMALL}
               color={Button.Colors.TRANSPARENT}
-              id="open-folder"
+              className='open-folder'
             > {Messages.REPLUGGED_PLUGINS_PATH}
             </Button>
           }
@@ -98,7 +98,7 @@ class BaseProduct extends React.PureComponent {
               color={Button.Colors.RED}
               look={Button.Looks.FILLED}
               size={Button.Sizes.SMALL}
-              id="uninstall"
+              className='uninstall'
             >
               {Messages.APPLICATION_CONTEXT_MENU_UNINSTALL}
             </Button>

--- a/src/Powercord/plugins/pc-moduleManager/components/parts/BaseProduct.jsx
+++ b/src/Powercord/plugins/pc-moduleManager/components/parts/BaseProduct.jsx
@@ -53,6 +53,7 @@ class BaseProduct extends React.PureComponent {
             look={Button.Looks.LINK}
             size={Button.Sizes.SMALL}
             color={Button.Colors.TRANSPARENT}
+            id="server-invite"
           > {Messages.REPLUGGED_PLUGINS_DISCORD}
           </Button>
           }
@@ -63,6 +64,7 @@ class BaseProduct extends React.PureComponent {
                 look={Button.Looks.LINK}
                 size={Button.Sizes.SMALL}
                 color={Button.Colors.TRANSPARENT}
+                id="website"
               > {Messages.REPLUGGED_PLUGINS_WEBSITE}
               </Button>
           }
@@ -73,6 +75,7 @@ class BaseProduct extends React.PureComponent {
               look={Button.Looks.LINK}
               size={Button.Sizes.SMALL}
               color={Button.Colors.TRANSPARENT}
+              id="git-repo"
             > {Messages.REPLUGGED_PLUGINS_GITHUB}
             </Button>
           }
@@ -83,6 +86,7 @@ class BaseProduct extends React.PureComponent {
               look={Button.Looks.LINK}
               size={Button.Sizes.SMALL}
               color={Button.Colors.TRANSPARENT}
+              id="open-folder"
             > {Messages.REPLUGGED_PLUGINS_PATH}
             </Button>
           }
@@ -94,6 +98,7 @@ class BaseProduct extends React.PureComponent {
               color={Button.Colors.RED}
               look={Button.Looks.FILLED}
               size={Button.Sizes.SMALL}
+              id="uninstall"
             >
               {Messages.APPLICATION_CONTEXT_MENU_UNINSTALL}
             </Button>


### PR DESCRIPTION
This PR adds `id` attributes to all buttons on product cards (i.e. Theme and Plugin cards) so that themes can easily customize them (say for instance, adding an icon next to the Discord invite button) without having to resort to hacky workarounds which usually have a tendency to break.