### PR TITLE
Make badge cache re-fetch after 30m

### DIFF
--- a/src/Powercord/coremods/badges/index.js
+++ b/src/Powercord/coremods/badges/index.js
@@ -29,7 +29,10 @@ async function injectUsers () {
             }
 
             delete cache[userId];
-            return {};
+            return {
+              badges: {},
+              lastFetch: Date.now()
+            };
           });
       }
 

--- a/src/Powercord/coremods/badges/index.js
+++ b/src/Powercord/coremods/badges/index.js
@@ -9,6 +9,7 @@ const { loadStyle, unloadStyle } = require('../util');
 const Badges = require('./Badges');
 
 const cache = { _guilds: {} };
+const REFRESH_INTERVAL = 1000 * 60 * 30;
 
 async function injectUsers () {
   const UserProfileBadgeList = getAllModules((m) => m.default?.displayName === 'UserProfileBadgeList')[1]; // Discord have two identical components but only 2nd is actually used?
@@ -16,7 +17,7 @@ async function injectUsers () {
     const [ badges, setBadges ] = React.useState(null);
     const userId = props.user.id;
     React.useEffect(async () => {
-      if (!cache[userId] || cache[userId].lastFetch < Date.now() - (1000 * 60 * 30)) {
+      if (!cache[userId] || cache[userId].lastFetch < Date.now() - REFRESH_INTERVAL) {
         const baseUrl = powercord.settings.get('backendURL', WEBSITE);
         cache[userId] = await get(`${baseUrl}/api/v1/users/${userId}`)
           .catch((e) => e)
@@ -123,7 +124,7 @@ async function injectGuilds () {
   });
 
   fetchGuilds();
-  setInterval(fetchGuilds, 1000 * 60 * 30);
+  setInterval(fetchGuilds, REFRESH_INTERVAL);
 }
 
 module.exports = async function () {

--- a/src/Powercord/coremods/badges/index.js
+++ b/src/Powercord/coremods/badges/index.js
@@ -82,6 +82,13 @@ async function injectUsers () {
   UserProfileBadgeList.default.displayName = 'UserProfileBadgeList';
 }
 
+async function fetchGuilds () {
+  const baseUrl = powercord.settings.get('backendURL', WEBSITE);
+  get(`${baseUrl}/api/v1/guilds/badges`).then(async res => {
+    cache._guilds = res.body;
+  });
+}
+
 async function injectGuilds () {
   const GuildHeader = await getModule([ 'AnimatedBanner', 'default' ]);
   const GuildBadge = await getModuleByDisplayName('GuildBadge');
@@ -112,12 +119,8 @@ async function injectGuilds () {
     return res;
   });
 
-  const baseUrl = powercord.settings.get('backendURL', WEBSITE);
-  get(`${baseUrl}/api/v1/guilds/badges`).then(async res => {
-    cache._guilds = res.body;
-    // const { container } = await getModule([ 'subscribeTooltipText' ]);
-    // forceUpdateElement(`.${container}`);
-  });
+  fetchGuilds();
+  setInterval(fetchGuilds, 1000 * 60 * 30);
 }
 
 module.exports = async function () {


### PR DESCRIPTION
User badges will re-fetch when their profile is viewed if it's been 30m since the last fetch
Guild badges will re-fetch every 30m
Closes #54 