### PR TITLE
Move Themes and Quick CSS to separate settings pages

### DIFF
--- a/src/Powercord/plugins/pc-moduleManager/components/manage/Themes.jsx
+++ b/src/Powercord/plugins/pc-moduleManager/components/manage/Themes.jsx
@@ -1,10 +1,8 @@
-const { React, getModule, i18n: { Messages } } = require('powercord/webpack');
-const { TabBar } = require('powercord/components');
+const { React, i18n: { Messages } } = require('powercord/webpack');
 const { open: openModal, close: closeModal } = require('powercord/modal');
 const { Confirm } = require('powercord/components/modal');
 
 const ThemeSettings = require('./ThemeSettings');
-const QuickCSS = require('./QuickCSS');
 const Base = require('./Base');
 const InstalledProduct = require('../parts/InstalledProduct');
 
@@ -25,8 +23,8 @@ class Themes extends Base {
         <ThemeSettings theme={this.state.settings} onClose={() => this.setState({ settings: null })}/>
       );
     }
-    
-    return super.render()
+
+    return super.render();
   }
 
   renderItem (item) {

--- a/src/Powercord/plugins/pc-moduleManager/components/manage/Themes.jsx
+++ b/src/Powercord/plugins/pc-moduleManager/components/manage/Themes.jsx
@@ -13,7 +13,6 @@ class Themes extends Base {
     super();
     this.state = {
       ...this.state,
-      tab: 'INSTALLED',
       tryBeta: false
     };
 
@@ -26,29 +25,8 @@ class Themes extends Base {
         <ThemeSettings theme={this.state.settings} onClose={() => this.setState({ settings: null })}/>
       );
     }
-
-    const { topPill, item } = getModule([ 'topPill' ], false);
-    return (
-      <>
-        <div className='powercord-entities-manage-tabs'>
-          <TabBar
-            selectedItem={this.state.tab}
-            onItemSelect={tab => this.setState({ tab })}
-            type={topPill}
-          >
-            <TabBar.Item className={item} selectedItem={this.state.tab} id='INSTALLED'>
-              {Messages.MANAGE_USER_SHORTHAND}
-            </TabBar.Item>
-            <TabBar.Item className={item} selectedItem={this.state.tab} id='QUICK_CSS'>
-              {Messages.REPLUGGED_QUICKCSS}
-            </TabBar.Item>
-          </TabBar>
-        </div>
-        {this.state.tab === 'INSTALLED'
-          ? super.render()
-          : <QuickCSS openPopout={this.props.openPopout}/>}
-      </>
-    );
+    
+    return super.render()
   }
 
   renderItem (item) {

--- a/src/Powercord/plugins/pc-moduleManager/index.js
+++ b/src/Powercord/plugins/pc-moduleManager/index.js
@@ -84,6 +84,14 @@ module.exports = class ModuleManager extends Plugin {
         ...props
       })
     });
+    powercord.api.settings.registerSettings('pc-moduleManager-css', {
+      category: this.entityID,
+      label: () => Messages.REPLUGGED_QUICKCSS,
+      render: (props) => React.createElement(QuickCSS, {
+        openPopout: () => this._openQuickCSSPopout(),
+        ...props
+      })
+    });
 
     if (powercord.api.labs.isExperimentEnabled('pc-moduleManager-deeplinks')) {
       deeplinks();


### PR DESCRIPTION
Separates the themes and quick CSS into their own settings for ease of navigation and discovery.

![image](https://user-images.githubusercontent.com/44992537/183492806-910ff8e2-e775-4262-8db8-01c279bf3305.png)
![image](https://user-images.githubusercontent.com/44992537/183492891-12fedc2d-9edf-4bcd-bea4-9df3325c7278.png)
