### PR TITLE
Make plugin installer links open in-app

### DIFF
--- a/src/Powercord/plugins/pc-routelinks/index.js
+++ b/src/Powercord/plugins/pc-routelinks/index.js
@@ -80,11 +80,11 @@ module.exports = class RDLinks extends Plugin {
         const match = (/^https?:\/\/(?:www\.)?replugged\.dev\/install\?url=(.*)$/).exec(link);
         if (match) {
           let url = decodeURIComponent(match[1]);
-          res.props.onClick = (e) => {
-            if (url.match(/^[\w-]+\/[\w-.]+$/)) {
-              url = `https://github.com/${url}`;
-            }
+          if (url.match(/^[\w-]+\/[\w-.]+$/)) {
+            url = `https://github.com/${url}`;
+          }
 
+          res.props.onClick = (e) => {
             e.preventDefault();
             this.handleRequest(url).then(data => {
               this.info = data.info;

--- a/src/Powercord/plugins/pc-routelinks/index.js
+++ b/src/Powercord/plugins/pc-routelinks/index.js
@@ -84,6 +84,9 @@ module.exports = class RDLinks extends Plugin {
             url = `https://github.com/${url}`;
           }
 
+          // Cache info so it's loaded when you click the link
+          getRepoInfo(url);
+
           res.props.onClick = (e) => {
             e.preventDefault();
             this.handleRequest(url).then(data => {

--- a/src/Powercord/plugins/pc-routelinks/index.js
+++ b/src/Powercord/plugins/pc-routelinks/index.js
@@ -2,11 +2,34 @@ const { Plugin } = require('powercord/entities');
 const { getRepoInfo, cloneRepo } = require('../pc-moduleManager/util');
 const express = require('express');
 const { open: openModal, close: closeModal } = require('powercord/modal');
-const { React } = require('powercord/webpack');
+const { getModule, React } = require('powercord/webpack');
 const Modal = require('./components/ConfirmModal');
+const { inject, uninject } = require('powercord/injector');
 
+const Anchor = getModule(m => m.default?.displayName === 'Anchor', false);
 
 module.exports = class RDLinks extends Plugin {
+  async handleRequest (address) {
+    this.info = await getRepoInfo(address);
+    if (this.info) {
+      this.info.url = address;
+      if (this.info.isInstalled) {
+        return ({
+          code: 'ALREADY-INSTALLED',
+          info: this.info
+        });
+      }
+
+      return ({
+        code: 'SUCCESS',
+        info: this.info
+      });
+    }
+    return ({
+      code: 'CANNOT-FIND'
+    });
+  }
+
   async startPlugin () {
     this.app = express();
 
@@ -18,28 +41,12 @@ module.exports = class RDLinks extends Plugin {
     });
 
     this.app.post('/install/', async (req, res) => {
-      this.info = await getRepoInfo(req.query.address);
-      if (this.info) {
-        this.info.url = req.query.address;
-        if (this.info.isInstalled) {
-          res.status(403).json({
-            code: 'ALREADY-INSTALLED',
-            info: this.info
-          });
-          return;
-        }
-
-        res.status(200).json({
-          code: 'SUCCESS',
-          info: this.info
-        });
-
+      const data = await this.handleRequest(req.query.address);
+      this.info = data.info;
+      if (data.code === 'SUCCESS') {
         this.openInstallModal();
-      } else {
-        res.status(404).json({
-          code: 'CANNOT-FIND'
-        });
       }
+      res.status(200).json(data);
     });
 
     const min_port = 6473;
@@ -64,6 +71,61 @@ module.exports = class RDLinks extends Plugin {
     });
 
     this.httpserv = await open(min_port);
+
+
+    inject('installer-open-in-app', Anchor, 'default', (_, res) => {
+      const link = res.props?.href?.toLowerCase();
+
+      if (link) {
+        const match = (/^https?:\/\/(?:www\.)?replugged\.dev\/install\?url=(.*)$/).exec(link);
+        if (match) {
+          let url = decodeURIComponent(match[1]);
+          res.props.onClick = (e) => {
+            if (url.match(/^[\w-]+\/[\w-.]+$/)) {
+              url = `https://github.com/${url}`;
+            }
+
+            e.preventDefault();
+            this.handleRequest(url).then(data => {
+              this.info = data.info;
+              if (data.code === 'SUCCESS') {
+                this.openInstallModal();
+              }
+              if (data.code === 'ALREADY-INSTALLED') {
+                powercord.api.notices.sendToast(`PDPluginAlreadyInstalled-${this.info.repoName}`, {
+                  header: `The ${this.info.type} ${this.info.repoName} is already installed.`,
+                  type: 'info',
+                  timeout: 10e3,
+                  buttons: [ {
+                    text: 'Got It',
+                    color: 'green',
+                    size: 'medium',
+                    look: 'outlined'
+                  } ]
+                });
+              }
+              if (data.code === 'CANNOT-FIND') {
+                powercord.api.notices.sendToast(`PDPluginCannotFind-${url}`, {
+                  header: `Could not find a plugin or theme repository at ${url}`,
+                  type: 'info',
+                  timeout: 10e3,
+                  buttons: [ {
+                    text: 'Got It',
+                    color: 'green',
+                    size: 'medium',
+                    look: 'outlined'
+                  } ]
+                });
+              }
+            });
+          };
+        }
+      }
+
+      return res;
+    });
+
+    Anchor.default.displayName = 'Anchor';
   }
 
   openInstallModal () {
@@ -108,5 +170,6 @@ module.exports = class RDLinks extends Plugin {
 
   async pluginWillUnload () {
     this.httpserv.close();
+    uninject('installer-open-in-app');
   }
 };


### PR DESCRIPTION
Follow-up to #42 
`https://replugged.dev/install?url=...` links will open the install prompt instead of opening your browser.