### PR TITLE
Make the plugin downloader recognize replugged.dev installer links

### DIFF
--- a/src/Powercord/plugins/pc-moduleManager/components/installer/Button.jsx
+++ b/src/Powercord/plugins/pc-moduleManager/components/installer/Button.jsx
@@ -1,17 +1,18 @@
 const { React } = require('powercord/webpack');
 const { Clickable } = require('powercord/components');
-const { cloneRepo, REPO_URL_REGEX } = require('../../util');
+const { cloneRepo, matchRepoURL } = require('../../util');
 
 module.exports = class Button extends React.Component {
   render () {
-    const [ GitURL, , RepoName ] = this.props.message.content.match(REPO_URL_REGEX) ?? [];
-    if (!GitURL) {
+    const match = matchRepoURL(this.props.message.content);
+    if (!match) {
       return <></>;
     }
+    const { url, repoName } = match;
 
     const installed = this.props.type === 'plugin'
-      ? powercord.pluginManager.isInstalled(RepoName)
-      : powercord.styleManager.isInstalled(RepoName);
+      ? powercord.pluginManager.isInstalled(repoName)
+      : powercord.styleManager.isInstalled(repoName);
 
     return (
       <div
@@ -24,7 +25,7 @@ module.exports = class Button extends React.Component {
             if (installed) {
               return;
             }
-            cloneRepo(GitURL, powercord, this.props.type);
+            cloneRepo(url, powercord, this.props.type);
           }}
         >
           {installed ? `${this.props.type === 'plugin' ? 'Plugin' : 'Theme'} Installed` : `Download ${this.props.type === 'plugin' ? 'Plugin' : 'Theme'}`}

--- a/src/Powercord/plugins/pc-moduleManager/util/getInfo.js
+++ b/src/Powercord/plugins/pc-moduleManager/util/getInfo.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 const { get } = require('powercord/http');
-const { REPO_URL_REGEX } = require('./misc');
+const { matchRepoURL } = require('./misc');
 
 /**
  * @type Map<string, 'plugin'|'theme'|null>
@@ -52,11 +52,14 @@ async function getRepoType (identifier) {
  * @returns {PluginInfo|Promise<PluginInfo|null>}
  */
 module.exports = function getRepoInfo (url) {
-  const urlMatch = url.match(REPO_URL_REGEX);
-  if (!urlMatch) {
+  const repoData = matchRepoURL(url);
+  if (!repoData) {
     return null;
   }
-  const [ , username, repoName, branch ] = urlMatch;
+
+  // eslint-disable-next-line prefer-destructuring
+  url = repoData.url;
+  const { username, repoName, branch } = repoData;
 
   const identifier = `${username}/${repoName}/${branch || ''}`;
 
@@ -67,6 +70,7 @@ module.exports = function getRepoInfo (url) {
   const isInstalled = powercord.pluginManager.isInstalled(repoName) || powercord.styleManager.isInstalled(repoName);
 
   const data = {
+    url,
     username,
     repoName,
     branch,

--- a/src/Powercord/plugins/pc-moduleManager/util/index.js
+++ b/src/Powercord/plugins/pc-moduleManager/util/index.js
@@ -1,11 +1,13 @@
 const getRepoInfo = require('./getInfo');
 const cloneRepo = require('./cloneRepo');
-const { resp, REPO_URL_REGEX } = require('./misc');
+const { resp, matchRepoURL, INSTALLER_URL_REGEX, REPO_URL_REGEX } = require('./misc');
 
 
 module.exports = {
   getRepoInfo,
   cloneRepo,
   resp,
+  matchRepoURL,
+  INSTALLER_URL_REGEX,
   REPO_URL_REGEX
 };

--- a/src/Powercord/plugins/pc-moduleManager/util/misc.js
+++ b/src/Powercord/plugins/pc-moduleManager/util/misc.js
@@ -1,4 +1,30 @@
-exports.REPO_URL_REGEX = /https?:\/\/(?:www\.)?github\.com\/([^/\s>]+)\/([^/\s>]+)(?:\/tree\/([^\s>]+))?/;
+const INSTALLER_URL_REGEX = /https?:\/\/(?:www\.)?replugged\.dev\/install\?url=(.*)/;
+const REPO_URL_REGEX = /https?:\/\/(?:www\.)?github\.com\/([^/\s>]+)\/([^/\s>]+)(?:\/tree\/([^\s>]+))?/;
+
+exports.INSTALLER_URL_REGEX = INSTALLER_URL_REGEX;
+exports.REPO_URL_REGEX = REPO_URL_REGEX;
+
+exports.matchRepoURL = (url) => {
+  const installerMatch = url.match(INSTALLER_URL_REGEX);
+  if (installerMatch) {
+    url = decodeURIComponent(installerMatch[1]);
+  }
+  if (url.match(/^[\w-]+\/[\w-.]+$/)) {
+    url = `https://github.com/${url}`;
+  }
+  const urlMatch = url.match(REPO_URL_REGEX);
+  if (!urlMatch) {
+    return null;
+  }
+  const [ , username, repoName, branch ] = urlMatch;
+
+  return {
+    url,
+    username,
+    repoName,
+    branch
+  };
+};
 
 exports.resp = (success, description) => ({
   send: false,

--- a/src/Powercord/plugins/pc-routelinks/index.js
+++ b/src/Powercord/plugins/pc-routelinks/index.js
@@ -89,8 +89,9 @@ module.exports = class RDLinks extends Plugin {
                 this.openInstallModal();
               }
               if (data.code === 'ALREADY-INSTALLED') {
-                powercord.api.notices.sendToast(`PDPluginAlreadyInstalled-${this.info.repoName}`, {
-                  header: `The ${this.info.type} ${this.info.repoName} is already installed.`,
+                powercord.api.notices.sendToast(`PDAlreadyInstalled-${this.info.repoName}`, {
+                  header: 'Plugin Already Installed',
+                  content: `${this.info.repoName} is already installed.`,
                   type: 'info',
                   timeout: 10e3,
                   buttons: [ {


### PR DESCRIPTION
Acts just like if it were a GitHub link
Also refactored (again lol)