### PR TITLE
Fix enabling experiments

### DIFF
--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -79,7 +79,7 @@
   "REPLUGGED_SETTINGS_DEBUG_LOGS": "Debug Logs",
   "REPLUGGED_SETTINGS_DEBUG_LOGS_DESC": "Saves console contents to a file. Useful for debugging if Discord is crashing unexpectedly.",
   "REPLUGGED_SETTINGS_DISCORD_EXPERIMENTS": "Enable Discord Experiments",
-  "REPLUGGED_SETTINGS_DISCORD_EXPERIMENTS_DESC": "****WARNING:**** Enabling this gives you access to features that can be detected by Discord and may result in an ****account termination****. Replugged is **not responsible** for what you do with this feature. Leave it disabled if you are unsure. The Replugged Team will **not** provide any support regarding any experiment.",
+  "REPLUGGED_SETTINGS_DISCORD_EXPERIMENTS_DESC": "****WARNING:**** Enabling this gives you access to features that can be detected by Discord and may result in an ****account termination****. Replugged is **not responsible** for what you do with this feature. Leave it disabled if you are unsure. The Replugged Team will **not** provide any support regarding any experiment. **Requires restart**.",
   "REPLUGGED_SETTINGS_EXP_WEB_PLATFORM": "Experimental Web Platform features",
   "REPLUGGED_SETTINGS_EXP_WEB_PLATFORM_DESC": "Enables Chromium's experimental Web Platform features that are in development, such as CSS \"backdrop-filter\". Since features are in development you may encounter issues and APIs may change at any time. **Requires restart**.",
   "REPLUGGED_SETTINGS_KEEP_TOKEN": "Keep token stored",

--- a/src/Powercord/plugins/pc-settings/components/GeneralSettings/index.jsx
+++ b/src/Powercord/plugins/pc-settings/components/GeneralSettings/index.jsx
@@ -1,10 +1,12 @@
-const { React, getModule, i18n: { Messages } } = require('powercord/webpack');
+const { React, i18n: { Messages } } = require('powercord/webpack');
 const { Icons: { FontAwesome } } = require('powercord/components');
 const { open: openModal, close: closeModal } = require('powercord/modal');
 const { TextInput, SwitchItem, ButtonItem, Category } = require('powercord/components/settings');
 const { Confirm } = require('powercord/components/modal');
 const { WEBSITE, CACHE_FOLDER } = require('powercord/constants');
 const { rmdirRf } = require('powercord/util');
+
+const { enableExperiments, disableExperiments } = require('../../experiments');
 
 const PassphraseModal = require('./PassphraseModal.jsx');
 const Account = require('./PowercordAccount');
@@ -114,8 +116,11 @@ module.exports = class GeneralSettings extends React.Component {
             onChange={async () => {
               toggleSetting('experiments');
               // Update modules
-              const experimentsModule = await getModule(r => r.isDeveloper !== void 0);
-              experimentsModule._changeCallbacks.forEach(cb => cb());
+              if (getSetting('experiments')) {
+                enableExperiments();
+              } else {
+                disableExperiments();
+              }
             }}
           >
             {Messages.REPLUGGED_SETTINGS_DISCORD_EXPERIMENTS}

--- a/src/Powercord/plugins/pc-settings/components/GeneralSettings/index.jsx
+++ b/src/Powercord/plugins/pc-settings/components/GeneralSettings/index.jsx
@@ -121,6 +121,7 @@ module.exports = class GeneralSettings extends React.Component {
               } else {
                 disableExperiments();
               }
+              this.askRestart();
             }}
           >
             {Messages.REPLUGGED_SETTINGS_DISCORD_EXPERIMENTS}

--- a/src/Powercord/plugins/pc-settings/experiments.js
+++ b/src/Powercord/plugins/pc-settings/experiments.js
@@ -1,0 +1,52 @@
+// Credit to Beefers for this snippet
+
+const { getModule } = require('powercord/webpack');
+
+let hasEnabled = false;
+
+async function enableExperiments () {
+  if (hasEnabled) {
+    return;
+  }
+
+  // Get the module used to get the current user, but not the one used elsewhere because discord™️
+  const userMod = getModule([ 'getUsers' ], false).__proto__;
+
+  // Get the connection open handler
+  const { CONNECTION_OPEN } = (await getModule([ 'isDeveloper' ]))._dispatcher._orderedActionHandlers;
+
+  function getHandler (handlerName) {
+    return CONNECTION_OPEN.find((x) => x.name === handlerName).actionHandler;
+  }
+
+  // Call the handler with fake data and mask the error that will always occur
+  try {
+    getHandler('ExperimentStore')({
+      user: { ...userMod.getCurrentUser(),
+        flags: 1 },
+      type: 'CONNECTION_OPEN'
+    });
+  } catch (e) {}
+
+  // Patch getCurrentUser to always return the staff flag check as true
+  const oldGCUser = userMod.getCurrentUser;
+  userMod.getCurrentUser = () => ({ ...oldGCUser(),
+    hasFlag: () => true });
+
+  // Call the second handler without data now that the flag always returns true
+  getHandler('DeveloperExperimentStore')();
+
+  // Unpatch getCurrentUser
+  userMod.getCurrentUser = oldGCUser;
+
+  hasEnabled = true;
+}
+
+async function disableExperiments () {
+  hasEnabled = false;
+}
+
+module.exports = {
+  enableExperiments,
+  disableExperiments
+};

--- a/src/Powercord/plugins/pc-settings/index.js
+++ b/src/Powercord/plugins/pc-settings/index.js
@@ -5,8 +5,11 @@ const { WEBSITE } = require('powercord/constants');
 const { Plugin } = require('powercord/entities');
 const { sleep } = require('powercord/util');
 
+const { enableExperiments } = require('./experiments');
+
 const ErrorBoundary = require('./components/ErrorBoundary');
 const GeneralSettings = require('./components/GeneralSettings');
+// const powercord = require('powercord/');
 // const Labs = require('./components/Labs');
 
 const FormTitle = AsyncComponent.from(getModuleByDisplayName('FormTitle'));
@@ -27,7 +30,9 @@ module.exports = class Settings extends Plugin {
 
     // this.patchSettingsContextMenu();
     this.patchSettingsComponent();
-    this.patchExperiments();
+    if (powercord.settings.get('experiments')) {
+      enableExperiments();
+    }
   }
 
   async pluginWillUnload () {
@@ -35,20 +40,6 @@ module.exports = class Settings extends Plugin {
     uninject('pc-settings-items');
     uninject('pc-settings-actions');
     uninject('pc-settings-errorHandler');
-  }
-
-  async patchExperiments () {
-    try {
-      const experimentsModule = await getModule(r => r.isDeveloper !== void 0);
-      Object.defineProperty(experimentsModule, 'isDeveloper', {
-        get: () => powercord.settings.get('experiments', false)
-      });
-
-      // Ensure components do get the update
-      experimentsModule._changeCallbacks.forEach(cb => cb());
-    } catch (_) {
-      // memes
-    }
   }
 
   async patchSettingsComponent () {


### PR DESCRIPTION
Fix the Discord experiments toggle. (Thank you Beef, I used the marked-up snippet here.) The only catch is that disabling experiments only sets the setting; it doesn’t actually disable them until the user reloads.