### PR TITLE
option to disable update toast

### DIFF
--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -145,6 +145,8 @@
   "REPLUGGED_UPDATES_OPTS_RELEASE_MODAL_HEADER": "Change release channel",
   "REPLUGGED_UPDATES_OPTS_RELEASE_STABLE_BTN": "Switch to stable",
   "REPLUGGED_UPDATES_OPTS_RELEASE_SWITCH": "Switch",
+  "REPLUGGED_UPDATES_OPTS_TOAST_ENABLED": "Show update checker toast",
+  "REPLUGGED_UPDATES_OPTS_TOAST_ENABLED_DESC": "Show an overlay over the client which says updates are being checked for, and if updates are found, prompt you to update. Only applies if update in background is disabled.",
   "REPLUGGED_UPDATES_PAUSE": "Pause Updates",
   "REPLUGGED_UPDATES_PAUSED": "Updates are paused.",
   "REPLUGGED_UPDATES_PAUSED_RESUME": "They will resume on next reload.",

--- a/src/Powercord/plugins/pc-updater/components/Settings.jsx
+++ b/src/Powercord/plugins/pc-updater/components/Settings.jsx
@@ -176,6 +176,13 @@ module.exports = class UpdaterSettings extends React.PureComponent {
         >
           {Messages.REPLUGGED_UPDATES_OPTS_AUTO}
         </SwitchItem>
+        <SwitchItem
+          value={this.props.getSetting('toastenabled', true)}
+          onChange={() => this.props.toggleSetting('toastenabled', true)}
+          note={Messages.REPLUGGED_UPDATES_OPTS_TOAST_ENABLED_DESC}
+        >
+          {Messages.REPLUGGED_UPDATES_OPTS_TOAST_ENABLED}
+        </SwitchItem>
         <TextInput
           note={Messages.REPLUGGED_UPDATES_OPTS_INTERVAL_DESC}
           onChange={val => this.props.updateSetting('interval', (Number(val) && Number(val) >= 10) ? Math.ceil(Number(val)) : 10, 15)}

--- a/src/Powercord/plugins/pc-updater/index.js
+++ b/src/Powercord/plugins/pc-updater/index.js
@@ -117,7 +117,7 @@ module.exports = class Updater extends Plugin {
     if (updates.length > 0) {
       if (this.settings.get('automatic', false)) {
         this.doUpdate();
-      } else if (!document.querySelector('#powercord-updater, .powercord-updater')) {
+      } else if (this.settings.get('toastenabled', true) && !document.querySelector('#powercord-updater, .powercord-updater')) {
         powercord.api.notices.sendToast('powercord-updater', {
           header: Messages.REPLUGGED_UPDATES_TOAST_AVAILABLE_HEADER,
           content: Messages.REPLUGGED_UPDATES_TOAST_AVAILABLE_DESC,
@@ -166,7 +166,7 @@ module.exports = class Updater extends Plugin {
     if (failed.length > 0) {
       this.settings.set('failed', true);
       this.settings.set('updates', failed);
-      if (!document.querySelector('#powercord-updater, .powercord-updater')) {
+      if (this.settings.get('toastenabled', true) && !document.querySelector('#powercord-updater, .powercord-updater')) {
         powercord.api.notices.sendToast('powercord-updater', {
           header: Messages.REPLUGGED_UPDATES_TOAST_FAILED,
           type: 'danger',


### PR DESCRIPTION
allows you to disable the update toast (updates are still checked for, but it won't show a message about it unless you visit the updater)