### PR TITLE
fix webpack.getModuleSourceById

### DIFF
--- a/src/fake_node_modules/powercord/webpack/index.js
+++ b/src/fake_node_modules/powercord/webpack/index.js
@@ -106,7 +106,7 @@ const webpack = {
   * @returns {Chunk} The chunk.
   */
   getChunkByModuleId (id) {
-    return webpackChunkdiscord_app.find(m => id in m[1]);
+    return Object.values(webpack.chunkCache).find(c => id in c[1]);
   },
 
   /**

--- a/src/fake_node_modules/powercord/webpack/lazy.js
+++ b/src/fake_node_modules/powercord/webpack/lazy.js
@@ -1,15 +1,20 @@
 /* eslint-disable callback-return */
 const listeners = new Map();
+const chunkCache = {};
 let originalPush;
 
 // lazily required since otherwise we have a circular dependency (index -> old.webpack -> lazy -> index)
 let pcWebpack;
 
 function onPush (chunk) {
+  const oldChunk = [ [...chunk[0]], {} ];
+  chunkCache[chunk[0][0]] = oldChunk;
+
   const modules = chunk[1];
 
   for (const id in modules) {
     const mod = modules[id];
+    oldChunk[1][id] = mod;
     modules[id] = function (module, exports, require) {
       try {
         mod(module, exports, require);
@@ -96,6 +101,7 @@ function waitFor (filter) {
 }
 
 module.exports = {
+  chunkCache,
   _patchPush,
   subscribe,
   waitFor

--- a/src/fake_node_modules/powercord/webpack/lazy.js
+++ b/src/fake_node_modules/powercord/webpack/lazy.js
@@ -7,7 +7,7 @@ let originalPush;
 let pcWebpack;
 
 function onPush (chunk) {
-  const oldChunk = [ [...chunk[0]], {} ];
+  const oldChunk = [ [ ...chunk[0] ], {} ];
   chunkCache[chunk[0][0]] = oldChunk;
 
   const modules = chunk[1];


### PR DESCRIPTION
5ffb67f broke `getModuleSourceById` by replacing all of the module functions in `webpackChunkdiscord_app`

This fixes it by creating a `webpack.chunkCache` of chunks with their old module functions
