### PR TITLE
lazy webpack: Copy props and toString onto factory replacement

### DIFF
--- a/src/fake_node_modules/powercord/webpack/index.js
+++ b/src/fake_node_modules/powercord/webpack/index.js
@@ -106,7 +106,7 @@ const webpack = {
   * @returns {Chunk} The chunk.
   */
   getChunkByModuleId (id) {
-    return Object.values(webpack.chunkCache).find(c => id in c[1]);
+    return webpackChunkdiscord_app.find((c) => id in c[1]);
   },
 
   /**
@@ -116,7 +116,7 @@ const webpack = {
   */
   getModuleSourceById (id) {
     const chunk = webpack.getChunkByModuleId(id);
-    return chunk[1][id];
+    return chunk?.[1][id] ?? null;
   },
 
   /**
@@ -125,15 +125,18 @@ const webpack = {
   * @returns {number[]} The 'to be lazy-loaded' chunk ids
   */
   getLazyLoadedChunkIdsByModuleId (id) {
-    const srcStr = webpack.getModuleSourceById(id).toString();
-    const requireArgument = srcStr.toString().match(/^\(.,.,(.)\)/)?.[1];
+    const srcStr = webpack.getModuleSourceById(id)?.toString();
+    if (!srcStr) {
+      return [];
+    }
+    const requireArgument = srcStr.match(/^\(.,.,(.)\)/)?.[1];
 
     if (!requireArgument) {
       return [];
     }
 
     const importPattern = new RegExp(`\\b${requireArgument}\\.e\\(\\d+\\)`, 'g');
-    const imports = srcStr.toString().match(importPattern);
+    const imports = srcStr.match(importPattern);
     const ids = imports.map(e => e.slice(4, -1));
     return ids;
   },

--- a/src/fake_node_modules/powercord/webpack/lazy.js
+++ b/src/fake_node_modules/powercord/webpack/lazy.js
@@ -1,20 +1,15 @@
 /* eslint-disable callback-return */
 const listeners = new Map();
-const chunkCache = {};
 let originalPush;
 
 // lazily required since otherwise we have a circular dependency (index -> old.webpack -> lazy -> index)
 let pcWebpack;
 
 function onPush (chunk) {
-  const oldChunk = [ [ ...chunk[0] ], {} ];
-  chunkCache[chunk[0][0]] = oldChunk;
-
   const modules = chunk[1];
 
   for (const id in modules) {
     const mod = modules[id];
-    oldChunk[1][id] = mod;
     modules[id] = function (module, exports, require) {
       try {
         mod(module, exports, require);
@@ -37,6 +32,18 @@ function onPush (chunk) {
         }
       }
     };
+
+    Object.defineProperties(modules[id], {
+      ...Object.getOwnPropertyDescriptors(mod),
+      toString: {
+        value: () => mod.toString(),
+        configurable: true,
+        writable: true
+      },
+      _repluggedOriginal: {
+        value: mod
+      }
+    });
   }
 
   return originalPush.call(webpackChunkdiscord_app, chunk);
@@ -101,7 +108,6 @@ function waitFor (filter) {
 }
 
 module.exports = {
-  chunkCache,
   _patchPush,
   subscribe,
   waitFor


### PR DESCRIPTION
Followup for #100, copies props and "_repluggedOriginal" onto replaced factory functions instead of keeping a separate cache