### PR TITLE
Add keys to InstalledProducts, fixes Cards opening wrong repos

### DIFF
--- a/src/Powercord/coremods/moduleManager/components/manage/Plugins.jsx
+++ b/src/Powercord/coremods/moduleManager/components/manage/Plugins.jsx
@@ -10,6 +10,7 @@ class Plugins extends Base {
   renderItem (item) {
     return (
       <InstalledProduct
+        key={item.entityID}
         product={item.manifest}
         isEnabled={powercord.pluginManager.isEnabled(item.entityID)}
         onToggle={async v => {

--- a/src/Powercord/coremods/moduleManager/components/manage/ThemeSettings.jsx
+++ b/src/Powercord/coremods/moduleManager/components/manage/ThemeSettings.jsx
@@ -96,6 +96,7 @@ class ThemeSettings extends React.PureComponent {
     }
     return plugins.map(plugin => (
       <InstalledProduct
+        key={plugin.file}
         isEnabled={this.props.getSetting('_enabledPlugins', []).includes(plugin.file)}
         product={{
           name: plugin.name,

--- a/src/Powercord/coremods/moduleManager/components/manage/Themes.jsx
+++ b/src/Powercord/coremods/moduleManager/components/manage/Themes.jsx
@@ -30,10 +30,11 @@ class Themes extends Base {
   renderItem (item) {
     return (
       <InstalledProduct
+        key={item.entityID}
         product={item.manifest}
         isEnabled={powercord.styleManager.isEnabled(item.entityID)}
         onToggle={async v => {
-          await this._toggle(item.entityID, v);
+          this._toggle(item.entityID, v);
           this.forceUpdate();
         }}
         path={item.entityPath}


### PR DESCRIPTION
This issue happens because render returns an array of these without keys so react uses the index as key. Consequently, if you enter a search term, the items will be filtered and the indexes will shift which confuses react. Explicitly specifying the key fixes this issue