### PR TITLE
Fix Replugged Updateable params

### DIFF
--- a/src/Powercord/index.js
+++ b/src/Powercord/index.js
@@ -47,7 +47,7 @@ const runMigrations = require('./migrations');
  */
 class Powercord extends Updatable {
   constructor () {
-    super(join(__dirname, '..', '..'), '', 'base', 'powercord');
+    super(join(__dirname, '..', '..'), 'base', '', 'powercord');
 
     this.api = {};
     this.gitInfos = {


### PR DESCRIPTION
c771a0a swapped the `entityType` and `entityID` params in the base `Powercord` class