### PR TITLE
fix: updater reload prompt

### DIFF
--- a/src/Powercord/coremods/updater/index.js
+++ b/src/Powercord/coremods/updater/index.js
@@ -23,6 +23,10 @@ class Updater {
     settings.set('checking_progress', null);
   }
 
+  setAwaitingReload () {
+    settings.set('awaiting_reload', true);
+  }
+
   async checkForUpdates (allConcurrent = false) {
     if (
       settings.get('disabled', false) ||

--- a/src/Powercord/index.js
+++ b/src/Powercord/index.js
@@ -249,7 +249,7 @@ class Powercord extends Updatable {
           } ]
         });
       }
-      updater.settings.set('awaiting_reload', true);
+      updater.setAwaitingReload();
     }
     return success;
   }


### PR DESCRIPTION
#108 introduced a small regression where the settings werent accessible from the outside:
![image](https://user-images.githubusercontent.com/55899582/185444420-24ad2470-77cd-45a4-8994-6f8548ba94e2.png)
