### PR TITLE
[Plugin Manager] Ignore dotfiles

### DIFF
--- a/src/Powercord/managers/plugins.js
+++ b/src/Powercord/managers/plugins.js
@@ -29,6 +29,11 @@ module.exports = class PluginManager {
 
   // Mount/load/enable/install shit
   mount (pluginID) {
+    if (pluginID.startsWith('.')) {
+      console.debug('%c[Replugged]', 'color: #7289da', 'Ignoring dotfile', pluginID);
+      return;
+    }
+
     let manifest;
     try {
       manifest = Object.assign({


### PR DESCRIPTION
Just silences a nuisance error for `.gitkeep`, `.DS_Store`, etc