### PR TITLE
chore: update settings form title styling to be in line with Discord's

### DIFF
--- a/src/Powercord/coremods/settings/index.js
+++ b/src/Powercord/coremods/settings/index.js
@@ -20,7 +20,7 @@ const FormSection = AsyncComponent.from(getModuleByDisplayName('FormSection'));
 function _renderWrapper (label, Component) {
   return React.createElement(ErrorBoundary, null,
     React.createElement(FormSection, {},
-      React.createElement(FormTitle, { tag: 'h2' }, label),
+      React.createElement(FormTitle, { tag: 'h1' }, label),
       React.createElement(Component)
     )
   );


### PR DESCRIPTION
Updates the tag of the `FormTitle` for settings screens from `h2` to `h1` to be in line with Discord's form title styling for other user setting titles.