### PR TITLE
Fix: "TypeError: Cannot read property 'match' of undefined"

### DIFF
--- a/src/Powercord/coremods/moduleManager/util/misc.js
+++ b/src/Powercord/coremods/moduleManager/util/misc.js
@@ -16,10 +16,10 @@ exports.matchRepoURL = (url) => {
   if (exports.isInstallerURL(url)) {
     url = new URL(url).searchParams.get('url');
   }
-  if (url.match(/^[\w-]+\/[\w-.]+$/)) {
+  if (url?.match(/^[\w-]+\/[\w-.]+$/)) {
     url = `https://github.com/${url}`;
   }
-  const urlMatch = url.match(REPO_URL_REGEX);
+  const urlMatch = url?.match(REPO_URL_REGEX);
   if (!urlMatch) {
     return null;
   }


### PR DESCRIPTION
## What is it?
This error comes from the recent [plugin-embeds](https://github.com/replugged-org/replugged/pull/28) addition, and it would cause Discord to crash. I'm not sure what in chat causes the error but I've managed to find a simple fix.

## Crash caused by plugins?
No, I removed all of my plugins. Doing so still gave the same result.

## Images
Crash GIF:
![Crash GIF](https://cdn.spin.rip/r/explorer_2134325934.gif)

DevConsole error:
![DevConsole error](https://cdn.spin.rip/r/DiscordDevelopment_6692594124.png)