### PR TITLE
Updater button wrap

### DIFF
--- a/src/Powercord/coremods/updater/style.scss
+++ b/src/Powercord/coremods/updater/style.scss
@@ -11,7 +11,17 @@
 
     .animated path + path {
       transform-origin: 50% 50%;
-      animation: rotate 1.2s infinite;
+      -webkit-animation: rotate 1.2s infinite;
+              animation: rotate 1.2s infinite;
+    }
+
+    @-webkit-keyframes rotate {
+      from {
+        transform: rotate(0deg);
+      }
+      to {
+        transform: rotate(360deg);
+      }
     }
 
     @keyframes rotate {
@@ -60,10 +70,12 @@
 
   .buttons {
     display: flex;
+    flex-wrap: wrap;
     margin-top: 25px;
 
-    button + button {
-      margin-left: 15px;
+    button:not(:last-child) {
+      margin-right: 15px;
+      margin-bottom: 15px;
     }
   }
 
@@ -133,7 +145,10 @@
   .debug-info {
     display: flex;
     color: var(--interactive-normal);
-    user-select: text;
+    -webkit-user-select: text;
+       -moz-user-select: text;
+        -ms-user-select: text;
+            user-select: text;
     cursor: text;
 
     &.copied b {
@@ -186,7 +201,10 @@
       }
 
       &> a {
-        user-select: none;
+        -webkit-user-select: none;
+           -moz-user-select: none;
+            -ms-user-select: none;
+                user-select: none;
       }
     }
 


### PR DESCRIPTION
Some languages' i18n strings for the updater buttons are too long, which results in text being cut off. This changes the styles to allow the buttons to wrap multiple lines if needed.

<img width="641" alt="Screenshot on 2022-08-24 at 20 05 19" src="https://user-images.githubusercontent.com/14863373/186550848-2f0c3251-a6a9-4153-ae51-835838c9fc19.png">

<img width="670" alt="Screenshot on 2022-08-24 at 20 03 34" src="https://user-images.githubusercontent.com/14863373/186550761-7278c11b-f934-4796-9397-6e64923eee9a.png">
