### PR TITLE
Memorize install directory on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ config.json
 
 # macOS
 .DS_Store
+
+.installdir-*

--- a/injectors/linux.js
+++ b/injectors/linux.js
@@ -7,7 +7,7 @@ const { BasicMessages, AnsiEscapes, PlatformNames } = require('./log');
 // This is to ensure the homedir we get is the actual user's homedir instead of root's homedir
 const homedir = execSync('grep $(logname) /etc/passwd | cut -d ":" -f6').toString().trim();
 
-const installDirFile = __dirname + '/../.installdir-';
+const installDirFile = join(__dirname, '../.installdir-');
 
 const KnownLinuxPaths = Object.freeze({
   stable: [


### PR DESCRIPTION
Port of [powercord-org/powercord#602](https://github.com/powercord-org/powercord/pull/602)'s first half (as the second half seems to have already been implemented, separately):

> Currently, if a user is using a non-standard Discord install location, they will have to enter it each time they inject and uninject Powercord. This PR will fix this by creating an `.installdir` file and using that if possible.

Seperate `.installdir` files will be made for different Discord branches - for instance, Canary will have `.installdir-canary` and PTB will have `.installdir-ptb`