### PR TITLE
Add missing parameter to format, fix url rendering

### DIFF
--- a/src/Powercord/coremods/routelinks/components/ConfirmModal.jsx
+++ b/src/Powercord/coremods/routelinks/components/ConfirmModal.jsx
@@ -1,9 +1,11 @@
-const { React, i18n: { Messages } } = require('powercord/webpack');
+const { React, i18n: { Messages }, getModuleByDisplayName } = require('powercord/webpack');
 const { Confirm } = require('powercord/components/modal');
 const {
   Text
 } = require('powercord/components');
 const { close: closeModal } = require('powercord/modal');
+
+const Anchor = getModuleByDisplayName('Anchor', false);
 
 let setting;
 
@@ -17,20 +19,27 @@ module.exports = class Modal extends React.Component {
       }
     }
 
+    const text = Messages.REPLUGGED_MODULE_MANAGER_CONFIRM_INSTALL.format({
+      type: this.props.type,
+      name: this.props.repoName,
+      url: '{url}', // Will be replaced later
+      branch: this.props.branch ? Messages.REPLUGGED_INSTALL_MODAL_BRANCH.format({ branch: this.props.branch }) : ''
+    });
+
+    const parts = text.split('{url}');
+    parts.splice(1, 0, <Anchor href={this.props.url}>{this.props.url}</Anchor>);
+
     return <Confirm
       red={true}
-      header={Messages.REPLUGGED_INSTALL_MODAL_HEADER.format({ name: this.props.repoName })}
+      header={Messages.REPLUGGED_INSTALL_MODAL_HEADER.format({ type: this.props.type })}
       confirmText={Messages.REPLUGGED_CONFIRM}
       cancelText={Messages.REPLUGGED_CANCEL}
       onConfirm={() => this.props.onConfirm()}
       onCancel={() => typeof this.props.onCancel !== 'undefined' ? this.props.onCancel() : closeModal()}
     >
-      <Text> {Messages.REPLUGGED_MODULE_MANAGER_CONFIRM_INSTALL.format({
-        type: this.props.type,
-        name: this.props.repoName,
-        url: <a href={this.props.url} target="_blank">{this.props.url}</a>,
-        branch: this.props.branch ? Messages.REPLUGGED_INSTALL_MODAL_BRANCH.format({ branch: this.props.branch }) : ''
-      })} </Text>
+      <Text>
+        {parts}
+      </Text>
     </Confirm>;
   }
 };


### PR DESCRIPTION
One of the strings was formatted with `name` instead of `type`, causing it to crash.
Fixes url rendering as `[object Object]`