### PR TITLE
Fix lint workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "main": "index.js",
   "scripts": {
     "test": "jest",
-    "lint": "eslint --ext js --ext jsx --fix src",
+    "lint": "eslint --ext js --ext jsx src",
+    "format": "npm run lint -- --fix",
     "plug": "node injectors/index.js inject --no-exit-codes",
     "unplug": "node injectors/index.js uninject --no-exit-codes",
     "repair": "npm run unplug && git pull && npm run plug",

--- a/src/Powercord/coremods/moduleManager/components/installer/Button.jsx
+++ b/src/Powercord/coremods/moduleManager/components/installer/Button.jsx
@@ -28,11 +28,13 @@ module.exports = class Button extends React.Component {
             cloneRepo(url, powercord, this.props.type);
           }}
         >
-          {installed ? Messages.REPLUGGED_BUTTON_INSTALLER_INSTALLED.format({
-            type: this.props.type === 'plugin' ? Messages.REPLUGGED_PLUGIN : Messages.REPLUGGED_THEME
-          }) : Messages.REPLUGGED_BUTTON_INSTALLER_DOWNLOAD.format({
-            type: this.props.type === 'plugin' ? Messages.REPLUGGED_PLUGIN : Messages.REPLUGGED_THEME
-          })}
+          {installed
+            ? Messages.REPLUGGED_BUTTON_INSTALLER_INSTALLED.format({
+              type: this.props.type === 'plugin' ? Messages.REPLUGGED_PLUGIN : Messages.REPLUGGED_THEME
+            })
+            : Messages.REPLUGGED_BUTTON_INSTALLER_DOWNLOAD.format({
+              type: this.props.type === 'plugin' ? Messages.REPLUGGED_PLUGIN : Messages.REPLUGGED_THEME
+            })}
         </Clickable>
       </div>
     );


### PR DESCRIPTION
#104 caused the linters to pass if there are any fixable changes, even though it should fail. This PR makes a separate "format" command with `--fix` so the workflow will fail for non-fixable changes again.