### PR TITLE
Coremods setting folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ settings/*.json
 settings/quickcss/*
 !settings/quickcss/.gitkeep
 
+settings/coremods/*
+!settings/coremods/.gitkeep
+
 config.json
 *injected.txt
 *.nogit.*

--- a/.gitignore
+++ b/.gitignore
@@ -17,11 +17,8 @@ themes/*
 
 settings/*.json
 
-settings/quickcss/*
-!settings/quickcss/.gitkeep
-
-settings/coremods/*
-!settings/coremods/.gitkeep
+settings/**/*.json
+settings/quickcss/*.css
 
 config.json
 *injected.txt

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "repair": "npm run unplug && git pull && npm run plug",
     "inject": "node injectors/index.js inject --no-exit-codes",
     "uninject": "node injectors/index.js uninject --no-exit-codes",
-    "remigrate": "rm -rf settings/coremods/migrations.json"
+    "remigrate": "rm -rf settings/core/migrations.json"
   },
   "repository": "https://github.com/replugged-org/replugged.git",
   "author": "Replugged",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "repair": "npm run unplug && git pull && npm run plug",
     "inject": "node injectors/index.js inject --no-exit-codes",
     "uninject": "node injectors/index.js uninject --no-exit-codes",
-    "remigrate": "rm -rf settings/rp-migrations.json"
+    "remigrate": "rm -rf settings/coremods/migrations.json"
   },
   "repository": "https://github.com/replugged-org/replugged.git",
   "author": "Replugged",

--- a/src/Powercord/coremods/moduleManager/commands/uninstall.js
+++ b/src/Powercord/coremods/moduleManager/commands/uninstall.js
@@ -50,7 +50,6 @@ module.exports = {
   autocomplete (args) {
     const plugins = Array.from(powercord.pluginManager.plugins.values())
       .filter(plugin =>
-        !plugin.entityID.startsWith('pc-') &&
         plugin.entityID.toLowerCase().includes(args[0]?.toLowerCase())
       );
 

--- a/src/Powercord/coremods/moduleManager/components/brrrrr/items/Products/parts/InstalledFooter.jsx
+++ b/src/Powercord/coremods/moduleManager/components/brrrrr/items/Products/parts/InstalledFooter.jsx
@@ -2,7 +2,7 @@ const { React, getModule, i18n: { Messages } } = require('powercord/webpack');
 const { Button, Spinner } = require('powercord/components');
 const { openURL } = getModule([ 'openURL' ], false);
 // @todo: merge with Product/
-module.exports = ({ id, installing, onUninstall }) =>
+module.exports = ({ installing, onUninstall }) =>
 
   <div className='btn-group-l'>
     {<Button

--- a/src/Powercord/coremods/moduleManager/components/brrrrr/items/Products/parts/InstalledFooter.jsx
+++ b/src/Powercord/coremods/moduleManager/components/brrrrr/items/Products/parts/InstalledFooter.jsx
@@ -5,7 +5,7 @@ const { openURL } = getModule([ 'openURL' ], false);
 module.exports = ({ id, installing, onUninstall }) =>
 
   <div className='btn-group-l'>
-    {!id.startsWith('pc-') && <Button
+    {<Button
       onClick={() => openURL('https://test.com')}
       look={Button.Looks.LINK}
       size={Button.Sizes.SMALL}
@@ -15,7 +15,7 @@ module.exports = ({ id, installing, onUninstall }) =>
     </Button>}
 
     <div className='btn-group'>
-      {!id.startsWith('pc-') && <Button
+      {<Button
         disabled={installing}
         onClick={onUninstall}
         color={Button.Colors.RED}

--- a/src/Powercord/coremods/moduleManager/index.js
+++ b/src/Powercord/coremods/moduleManager/index.js
@@ -194,7 +194,7 @@ async function _loadQuickCSS () {
   _quickCSSElement.id = 'powercord-quickcss';
   document.head.appendChild(_quickCSSElement);
   if (existsSync(_quickCSSFile)) {
-    const settings = powercord.api.settings.buildCategoryObject('pc-moduleManager');
+    const settings = powercord.api.settings.buildCategoryObject('coremods/moduleManager');
     _quickCSS = await readFile(_quickCSSFile, 'utf8');
     powercord.api.moduleManager._quickCSS = _quickCSS;
     if (settings.get('qcss-enabled', true)) {

--- a/src/Powercord/coremods/moduleManager/index.js
+++ b/src/Powercord/coremods/moduleManager/index.js
@@ -6,7 +6,7 @@ const { React, getModule, i18n: { Messages } } = require('powercord/webpack');
 const { PopoutWindow } = require('powercord/components');
 const { inject, uninject } = require('powercord/injector');
 const { findInReactTree, forceUpdateElement } = require('powercord/util');
-const { SpecialChannels: { CSS_SNIPPETS, STORE_PLUGINS, STORE_THEMES }, WEBSITE } = require('powercord/constants');
+const { CSS_FILE, SpecialChannels: { CSS_SNIPPETS, STORE_PLUGINS, STORE_THEMES }, WEBSITE } = require('powercord/constants');
 const { join } = require('path');
 const commands = require('./commands');
 const deeplinks = require('./deeplinks');
@@ -23,7 +23,7 @@ const { injectContextMenu } = require('powercord/util');
 const Menu = getModule([ 'MenuItem' ], false);
 
 let _quickCSS = '';
-const _quickCSSFile = join(__dirname, '..', '..', '..', '..', 'settings', 'quickcss', 'main.css');
+const _quickCSSFile = CSS_FILE;
 let _quickCSSElement;
 
 async function _installerInjectCtxMenu () {
@@ -194,7 +194,7 @@ async function _loadQuickCSS () {
   _quickCSSElement.id = 'powercord-quickcss';
   document.head.appendChild(_quickCSSElement);
   if (existsSync(_quickCSSFile)) {
-    const settings = powercord.api.settings.buildCategoryObject('coremods/moduleManager');
+    const settings = powercord.api.settings.buildCategoryObject('pc-moduleManager');
     _quickCSS = await readFile(_quickCSSFile, 'utf8');
     powercord.api.moduleManager._quickCSS = _quickCSS;
     if (settings.get('qcss-enabled', true)) {

--- a/src/Powercord/coremods/updater/components/Settings.jsx
+++ b/src/Powercord/coremods/updater/components/Settings.jsx
@@ -312,7 +312,7 @@ module.exports = class UpdaterSettings extends React.PureComponent {
     const unauthorizedPlugins = Array.from(powercord.pluginManager.plugins.values()).filter(plugin =>
       plugin.__shortCircuit).map(plugin => plugin.manifest.name);
     const plugins = powercord.pluginManager.getPlugins().filter(plugin =>
-      !powercord.pluginManager.get(plugin).isInternal && powercord.pluginManager.isEnabled(plugin)
+      powercord.pluginManager.isEnabled(plugin)
     );
 
     const enabledLabs = powercord.api.labs.experiments.filter(e => powercord.api.labs.isExperimentEnabled(e.id));

--- a/src/Powercord/coremods/updater/index.js
+++ b/src/Powercord/coremods/updater/index.js
@@ -9,7 +9,7 @@ const { join } = require('path');
 const Settings = require('./components/Settings.jsx');
 const changelog = require('../../../../changelogs.json');
 
-const settings = powercord.api.settings.buildCategoryObject('pc-updater');
+const settings = powercord.api.settings.buildCategoryObject('coremods/updater');
 
 class Updater {
   constructor () {

--- a/src/Powercord/coremods/updater/index.js
+++ b/src/Powercord/coremods/updater/index.js
@@ -9,7 +9,7 @@ const { join } = require('path');
 const Settings = require('./components/Settings.jsx');
 const changelog = require('../../../../changelogs.json');
 
-const settings = powercord.api.settings.buildCategoryObject('coremods/updater');
+const settings = powercord.api.settings.buildCategoryObject('core/updater');
 
 class Updater {
   constructor () {

--- a/src/Powercord/coremods/updater/index.js
+++ b/src/Powercord/coremods/updater/index.js
@@ -40,7 +40,7 @@ class Updater {
     settings.set('checking_progress', [ 0, 0 ]);
     const disabled = settings.get('entities_disabled', []).map(e => e.id);
     const skipped = settings.get('entities_skipped', []);
-    const plugins = [ ...powercord.pluginManager.plugins.values() ].filter(p => !p.isInternal);
+    const plugins = [ ...powercord.pluginManager.plugins.values() ];
     const themes = [ ...powercord.styleManager.themes.values() ];
 
     const entities = plugins.concat(themes).filter(e => !disabled.includes(e.updateIdentifier) && e.isUpdatable());

--- a/src/Powercord/index.js
+++ b/src/Powercord/index.js
@@ -116,7 +116,7 @@ class Powercord extends Updatable {
   async startup () {
     // APIs
     await this.apiManager.startAPIs();
-    this.settings = powercord.api.settings.buildCategoryObject('coremods/general');
+    this.settings = powercord.api.settings.buildCategoryObject('pc-general');
     this.emit('settingsReady');
 
     // Migrations

--- a/src/Powercord/index.js
+++ b/src/Powercord/index.js
@@ -116,7 +116,7 @@ class Powercord extends Updatable {
   async startup () {
     // APIs
     await this.apiManager.startAPIs();
-    this.settings = powercord.api.settings.buildCategoryObject('pc-general');
+    this.settings = powercord.api.settings.buildCategoryObject('coremods/general');
     this.emit('settingsReady');
 
     // Migrations

--- a/src/Powercord/managers/plugins.js
+++ b/src/Powercord/managers/plugins.js
@@ -164,10 +164,6 @@ module.exports = class PluginManager {
   }
 
   async uninstall (pluginID) {
-    if (pluginID.startsWith('pc-')) {
-      throw new Error(`You cannot uninstall an internal plugin. (Tried to uninstall ${pluginID})`);
-    }
-
     await this.unmount(pluginID);
     await rmdirRf(resolve(this.pluginDir, pluginID));
   }

--- a/src/Powercord/managers/styles.js
+++ b/src/Powercord/managers/styles.js
@@ -43,7 +43,7 @@ module.exports = class StyleManager {
       if (!this.__settings) {
         this.__settings = {};
         try {
-          this.__settings = require(join(SETTINGS_FOLDER, 'coremods', 'general.json'));
+          this.__settings = require(join(SETTINGS_FOLDER, 'core', 'general.json'));
         } catch (e) {}
         return this.__settings.disabledThemes || [];
       }

--- a/src/Powercord/managers/styles.js
+++ b/src/Powercord/managers/styles.js
@@ -43,7 +43,7 @@ module.exports = class StyleManager {
       if (!this.__settings) {
         this.__settings = {};
         try {
-          this.__settings = require(join(SETTINGS_FOLDER, 'pc-general.json'));
+          this.__settings = require(join(SETTINGS_FOLDER, 'coremods' , 'general.json'));
         } catch (e) {}
         return this.__settings.disabledThemes || [];
       }

--- a/src/Powercord/managers/styles.js
+++ b/src/Powercord/managers/styles.js
@@ -43,7 +43,7 @@ module.exports = class StyleManager {
       if (!this.__settings) {
         this.__settings = {};
         try {
-          this.__settings = require(join(SETTINGS_FOLDER, 'coremods' , 'general.json'));
+          this.__settings = require(join(SETTINGS_FOLDER, 'coremods', 'general.json'));
         } catch (e) {}
         return this.__settings.disabledThemes || [];
       }

--- a/src/Powercord/migrations/20220908-move-coremods-settings.js
+++ b/src/Powercord/migrations/20220908-move-coremods-settings.js
@@ -1,13 +1,13 @@
 const { existsSync, renameSync, unlinkSync } = require('fs');
+const { SETTINGS_FOLDER } = require('powercord/constants');
 const path = require('path');
 
 module.exports = () => {
-  const settingsPath = `${__dirname}/../../../settings`;
   const files = {
-    'pc-general.json': 'coremods/general.json',
-    'pc-moduleManager.json': 'coremods/moduleManager.json',
-    'pc-updater.json': 'coremods/updater.json',
-    'rp-migrations.json': 'coremods/migrations.json',
+    'pc-general.json': 'core/general.json',
+    'pc-moduleManager.json': 'core/moduleManager.json',
+    'pc-updater.json': 'core/updater.json',
+    'rp-migrations.json': 'core/migrations.json',
     'pc-clickableEdits.json': 'clickableEdits.json',
     'pc-emojiUtility.json': 'emojiUtility.json',
     'pc-heygirl.json': 'heygirl.json',
@@ -20,8 +20,8 @@ module.exports = () => {
   };
 
   for (const setting in files) {
-    const source = path.resolve(`${settingsPath}/${setting}`);
-    const target = path.resolve(`${settingsPath}/${files[setting]}`);
+    const source = path.resolve(`${SETTINGS_FOLDER}/${setting}`);
+    const target = path.resolve(`${SETTINGS_FOLDER}/${files[setting]}`);
 
     if (existsSync(source)) {
       if (!existsSync(target)) {

--- a/src/Powercord/migrations/20220908-move-coremods-settings.js
+++ b/src/Powercord/migrations/20220908-move-coremods-settings.js
@@ -21,5 +21,39 @@ module.exports = () => {
 
   // Check formerly built in plugins.
 
+  if (existsSync(`${__dirname}/../../../settings/pc-clickableEdits.json`)) {
+    renameSync(`${__dirname}/../../../settings/pc-clickableEdits.json`, `${__dirname}/../../../settings/clickableEdits.json`);
+  }
+
+  if (existsSync(`${__dirname}/../../../settings/pc-emojiUtility.json`)) {
+    renameSync(`${__dirname}/../../../settings/pc-emojiUtility.json`, `${__dirname}/../../../settings/emojiUtility.json`);
+  }
   
+  if (existsSync(`${__dirname}/../../../settings/pc-heygirl.json`)) {
+    renameSync(`${__dirname}/../../../settings/pc-heygirl.json`, `${__dirname}/../../../settings/heygirl.json`);
+  }
+
+  if (existsSync(`${__dirname}/../../../settings/pc-clickableEdits.json`)) {
+    renameSync(`${__dirname}/../../../settings/pc-clickableEdits.json`, `${__dirname}/../../../settings/clickableEdits.json`);
+  }
+
+  if (existsSync(`${__dirname}/../../../settings/pc-codeblocks.json`)) {
+    renameSync(`${__dirname}/../../../settings/pc-codeblocks.json`, `${__dirname}/../../../settings/better-codeblocks.json`);
+  }
+  
+  if (existsSync(`${__dirname}/../../../settings/pc-lmgtfy.json`)) {
+    renameSync(`${__dirname}/../../../settings/pc-lmgtfy.json`, `${__dirname}/../../../settings/lmgtfy.json`);
+  }
+
+  if (existsSync(`${__dirname}/../../../settings/pc-mock.json`)) {
+    renameSync(`${__dirname}/../../../settings/pc-mock.json`, `${__dirname}/../../../settings/mock.json`);
+  }
+
+  if (existsSync(`${__dirname}/../../../settings/pc-tags.json`)) {
+    renameSync(`${__dirname}/../../../settings/pc-tags.json`, `${__dirname}/../../../settings/tags.json`);
+  }
+  
+  if (existsSync(`${__dirname}/../../../settings/pc-spotify.json`)) {
+    renameSync(`${__dirname}/../../../settings/pc-spotify.json`, `${__dirname}/../../../settings/spotify-modal.json`);
+  }
 };

--- a/src/Powercord/migrations/20220908-move-coremods-settings.js
+++ b/src/Powercord/migrations/20220908-move-coremods-settings.js
@@ -16,7 +16,7 @@ module.exports = () => {
     'pc-lmgtfy.json': 'lmgtfy.json',
     'pc-mock.json': 'mock.json',
     'pc-tags.json': 'tags.json',
-    'pc-spotify.json': 'spotify-modal.json',
+    'pc-spotify.json': 'spotify-modal.json'
   };
 
   for (const setting in files) {

--- a/src/Powercord/migrations/20220908-move-coremods-settings.js
+++ b/src/Powercord/migrations/20220908-move-coremods-settings.js
@@ -2,7 +2,6 @@ const { existsSync, renameSync, unlinkSync } = require('fs');
 const path = require('path');
 
 module.exports = () => {
-
   const settingsPath = `${__dirname}/../../../settings`;
   const files = {
     'pc-general.json': 'coremods/general.json',
@@ -17,13 +16,13 @@ module.exports = () => {
     'pc-lmgtfy.json': 'lmgtfy.json',
     'pc-mock.json': 'mock.json',
     'pc-tags.json': 'tags.json',
-    'pc-spotify.json': 'spotify-modal.json'
+    'pc-spotify.json': 'spotify-modal.json',
   };
 
   for (const setting in files) {
     const source = path.resolve(`${settingsPath}/${setting}`);
     const target = path.resolve(`${settingsPath}/${files[setting]}`);
-  
+
     if (existsSync(source)) {
       if (!existsSync(target)) {
         renameSync(source, target);

--- a/src/Powercord/migrations/20220908-move-coremods-settings.js
+++ b/src/Powercord/migrations/20220908-move-coremods-settings.js
@@ -1,59 +1,30 @@
-const { existsSync, renameSync } = require('fs');
+const { existsSync, renameSync, unlinkSync } = require('fs');
+const path = require('path');
 
 module.exports = () => {
-  // Check if coremod settings exist.
 
-  if (existsSync(`${__dirname}/../../../settings/pc-general.json`)) {
-    renameSync(`${__dirname}/../../../settings/pc-general.json`, `${__dirname}/../../../settings/coremods/general.json`);
-  }
+  const settingsPath = `${__dirname}/../../../settings`;
+  const files = {
+    "pc-general.json": "coremods/general.json",
+    "pc-moduleManager.json": "coremods/moduleManager.json",
+    "pc-updater.json": "coremods/updater.json",
+    "rp-migrations.json": "coremods/migrations.json",
+    "pc-clickableEdits.json": "clickableEdits.json",
+    "pc-emojiUtility.json": "emojiUtility.json",
+    "pc-heygirl.json": "heygirl.json",
+    "pc-hastebin.json": "hastebin.json",
+    "pc-codeblocks.json": "better-codeblocks.json",
+    "pc-lmgtfy.json": "lmgtfy.json",
+    "pc-mock.json": "mock.json",
+    "pc-tags.json": "tags.json",
+    "pc-spotify.json": "spotify-modal.json"
+  };
 
-  if (existsSync(`${__dirname}/../../../settings/pc-moduleManager.json`)) {
-    renameSync(`${__dirname}/../../../settings/pc-moduleManager.json`, `${__dirname}/../../../settings/coremods/moduleManager.json`);
-  }
-
-  if (existsSync(`${__dirname}/../../../settings/pc-updater.json`)) {
-    renameSync(`${__dirname}/../../../settings/pc-updater.json`, `${__dirname}/../../../settings/coremods/updater.json`);
-  }
-
-  if (existsSync(`${__dirname}/../../../settings/rp-migrations.json`)) {
-    renameSync(`${__dirname}/../../../settings/rp-migrations.json`, `${__dirname}/../../../settings/coremods/migrations.json`);
-  }
-
-  // Check formerly built in plugins.
-
-  if (existsSync(`${__dirname}/../../../settings/pc-clickableEdits.json`)) {
-    renameSync(`${__dirname}/../../../settings/pc-clickableEdits.json`, `${__dirname}/../../../settings/clickableEdits.json`);
-  }
-
-  if (existsSync(`${__dirname}/../../../settings/pc-emojiUtility.json`)) {
-    renameSync(`${__dirname}/../../../settings/pc-emojiUtility.json`, `${__dirname}/../../../settings/emojiUtility.json`);
-  }
-
-  if (existsSync(`${__dirname}/../../../settings/pc-heygirl.json`)) {
-    renameSync(`${__dirname}/../../../settings/pc-heygirl.json`, `${__dirname}/../../../settings/heygirl.json`);
-  }
-
-  if (existsSync(`${__dirname}/../../../settings/pc-clickableEdits.json`)) {
-    renameSync(`${__dirname}/../../../settings/pc-clickableEdits.json`, `${__dirname}/../../../settings/clickableEdits.json`);
-  }
-
-  if (existsSync(`${__dirname}/../../../settings/pc-codeblocks.json`)) {
-    renameSync(`${__dirname}/../../../settings/pc-codeblocks.json`, `${__dirname}/../../../settings/better-codeblocks.json`);
-  }
-
-  if (existsSync(`${__dirname}/../../../settings/pc-lmgtfy.json`)) {
-    renameSync(`${__dirname}/../../../settings/pc-lmgtfy.json`, `${__dirname}/../../../settings/lmgtfy.json`);
-  }
-
-  if (existsSync(`${__dirname}/../../../settings/pc-mock.json`)) {
-    renameSync(`${__dirname}/../../../settings/pc-mock.json`, `${__dirname}/../../../settings/mock.json`);
-  }
-
-  if (existsSync(`${__dirname}/../../../settings/pc-tags.json`)) {
-    renameSync(`${__dirname}/../../../settings/pc-tags.json`, `${__dirname}/../../../settings/tags.json`);
-  }
-
-  if (existsSync(`${__dirname}/../../../settings/pc-spotify.json`)) {
-    renameSync(`${__dirname}/../../../settings/pc-spotify.json`, `${__dirname}/../../../settings/spotify-modal.json`);
+  for (const setting in files) {
+    if (existsSync(`${settingsPath}/${setting}`)) {
+      if (!existsSync(`${settingsPath}/${files[setting]}`)) {
+        renameSync(`${settingsPath}/${setting}`, `${settingsPath}/${files[setting]}`);
+      }
+    }
   }
 };

--- a/src/Powercord/migrations/20220908-move-coremods-settings.js
+++ b/src/Powercord/migrations/20220908-move-coremods-settings.js
@@ -28,7 +28,7 @@ module.exports = () => {
   if (existsSync(`${__dirname}/../../../settings/pc-emojiUtility.json`)) {
     renameSync(`${__dirname}/../../../settings/pc-emojiUtility.json`, `${__dirname}/../../../settings/emojiUtility.json`);
   }
-  
+
   if (existsSync(`${__dirname}/../../../settings/pc-heygirl.json`)) {
     renameSync(`${__dirname}/../../../settings/pc-heygirl.json`, `${__dirname}/../../../settings/heygirl.json`);
   }
@@ -40,7 +40,7 @@ module.exports = () => {
   if (existsSync(`${__dirname}/../../../settings/pc-codeblocks.json`)) {
     renameSync(`${__dirname}/../../../settings/pc-codeblocks.json`, `${__dirname}/../../../settings/better-codeblocks.json`);
   }
-  
+
   if (existsSync(`${__dirname}/../../../settings/pc-lmgtfy.json`)) {
     renameSync(`${__dirname}/../../../settings/pc-lmgtfy.json`, `${__dirname}/../../../settings/lmgtfy.json`);
   }
@@ -52,7 +52,7 @@ module.exports = () => {
   if (existsSync(`${__dirname}/../../../settings/pc-tags.json`)) {
     renameSync(`${__dirname}/../../../settings/pc-tags.json`, `${__dirname}/../../../settings/tags.json`);
   }
-  
+
   if (existsSync(`${__dirname}/../../../settings/pc-spotify.json`)) {
     renameSync(`${__dirname}/../../../settings/pc-spotify.json`, `${__dirname}/../../../settings/spotify-modal.json`);
   }

--- a/src/Powercord/migrations/20220908-move-coremods-settings.js
+++ b/src/Powercord/migrations/20220908-move-coremods-settings.js
@@ -1,0 +1,25 @@
+const { existsSync, renameSync } = require('fs');
+
+module.exports = () => {
+  // Check if coremod settings exist.
+
+  if (existsSync(`${__dirname}/../../../settings/pc-general.json`)) {
+    renameSync(`${__dirname}/../../../settings/pc-general.json`, `${__dirname}/../../../settings/coremods/general.json`);
+  }
+
+  if (existsSync(`${__dirname}/../../../settings/pc-moduleManager.json`)) {
+    renameSync(`${__dirname}/../../../settings/pc-moduleManager.json`, `${__dirname}/../../../settings/coremods/moduleManager.json`);
+  }
+
+  if (existsSync(`${__dirname}/../../../settings/pc-updater.json`)) {
+    renameSync(`${__dirname}/../../../settings/pc-updater.json`, `${__dirname}/../../../settings/coremods/updater.json`);
+  }
+
+  if (existsSync(`${__dirname}/../../../settings/rp-migrations.json`)) {
+    renameSync(`${__dirname}/../../../settings/rp-migrations.json`, `${__dirname}/../../../settings/coremods/migrations.json`);
+  }
+
+  // Check formerly built in plugins.
+
+  
+};

--- a/src/Powercord/migrations/20220908-move-coremods-settings.js
+++ b/src/Powercord/migrations/20220908-move-coremods-settings.js
@@ -5,25 +5,31 @@ module.exports = () => {
 
   const settingsPath = `${__dirname}/../../../settings`;
   const files = {
-    "pc-general.json": "coremods/general.json",
-    "pc-moduleManager.json": "coremods/moduleManager.json",
-    "pc-updater.json": "coremods/updater.json",
-    "rp-migrations.json": "coremods/migrations.json",
-    "pc-clickableEdits.json": "clickableEdits.json",
-    "pc-emojiUtility.json": "emojiUtility.json",
-    "pc-heygirl.json": "heygirl.json",
-    "pc-hastebin.json": "hastebin.json",
-    "pc-codeblocks.json": "better-codeblocks.json",
-    "pc-lmgtfy.json": "lmgtfy.json",
-    "pc-mock.json": "mock.json",
-    "pc-tags.json": "tags.json",
-    "pc-spotify.json": "spotify-modal.json"
+    'pc-general.json': 'coremods/general.json',
+    'pc-moduleManager.json': 'coremods/moduleManager.json',
+    'pc-updater.json': 'coremods/updater.json',
+    'rp-migrations.json': 'coremods/migrations.json',
+    'pc-clickableEdits.json': 'clickableEdits.json',
+    'pc-emojiUtility.json': 'emojiUtility.json',
+    'pc-heygirl.json': 'heygirl.json',
+    'pc-hastebin.json': 'hastebin.json',
+    'pc-codeblocks.json': 'better-codeblocks.json',
+    'pc-lmgtfy.json': 'lmgtfy.json',
+    'pc-mock.json': 'mock.json',
+    'pc-tags.json': 'tags.json',
+    'pc-spotify.json': 'spotify-modal.json'
   };
 
   for (const setting in files) {
-    if (existsSync(`${settingsPath}/${setting}`)) {
-      if (!existsSync(`${settingsPath}/${files[setting]}`)) {
-        renameSync(`${settingsPath}/${setting}`, `${settingsPath}/${files[setting]}`);
+    const source = path.resolve(`${settingsPath}/${setting}`);
+    const target = path.resolve(`${settingsPath}/${files[setting]}`);
+  
+    if (existsSync(source)) {
+      if (!existsSync(target)) {
+        renameSync(source, target);
+        if (existsSync(source)) {
+          unlinkSync(source);
+        }
       }
     }
   }

--- a/src/Powercord/migrations/index.js
+++ b/src/Powercord/migrations/index.js
@@ -1,5 +1,5 @@
 module.exports = async (powercord) => {
-  const settings = powercord.api.settings.buildCategoryObject('coremods/migrations');
+  const settings = powercord.api.settings.buildCategoryObject('core/migrations');
   const migrations = settings.get('migrations-ran', []);
 
   const toRun = [];

--- a/src/Powercord/migrations/index.js
+++ b/src/Powercord/migrations/index.js
@@ -1,5 +1,5 @@
 module.exports = async (powercord) => {
-  const settings = powercord.api.settings.buildCategoryObject('rp-migrations');
+  const settings = powercord.api.settings.buildCategoryObject('coremods/migrations');
   const migrations = settings.get('migrations-ran', []);
 
   const toRun = [];

--- a/src/browserWindow.js
+++ b/src/browserWindow.js
@@ -5,7 +5,7 @@ let settings = {};
 let transparency = false;
 let ewp = false;
 try {
-  settings = require(join(__dirname, '../settings/pc-general.json'));
+  settings = require(join(__dirname, '../settings/coremods/general.json'));
   transparency = settings.transparentWindow;
   ewp = settings.experimentalWebPlatform;
 } catch (e) {}

--- a/src/browserWindow.js
+++ b/src/browserWindow.js
@@ -5,7 +5,7 @@ let settings = {};
 let transparency = false;
 let ewp = false;
 try {
-  settings = require(join(__dirname, '../settings/coremods/general.json'));
+  settings = require(join(__dirname, '../settings/core/general.json'));
   transparency = settings.transparentWindow;
   ewp = settings.experimentalWebPlatform;
 } catch (e) {}

--- a/src/fake_node_modules/powercord/constants.js
+++ b/src/fake_node_modules/powercord/constants.js
@@ -8,8 +8,10 @@ module.exports = Object.freeze({
 
   // Runtime
   SETTINGS_FOLDER: join(__dirname, '..', '..', '..', 'settings'),
+  CORE_SETTINGS_FOLDER: join(__dirname, '..', '..', '..', 'settings', 'core'),
   CACHE_FOLDER: join(__dirname, '..', '..', '..', '.cache'),
   LOGS_FOLDER: join(__dirname, '..', '..', '..', '.logs'),
+  CSS_FILE: join(__dirname, '..', '..', '..', 'settings', 'quickcss', 'main.css'),
 
   // Discord Server
   DISCORD_INVITE: 'B2TcnXV9Rg',

--- a/src/fake_node_modules/powercord/entities/Plugin.js
+++ b/src/fake_node_modules/powercord/entities/Plugin.js
@@ -20,10 +20,6 @@ class Plugin extends Updatable {
   }
 
   // Getters
-  get isInternal () {
-    return this.entityID.startsWith('pc-');
-  }
-
   get dependencies () {
     return this.manifest.dependencies;
   }


### PR DESCRIPTION
Moves coremods settings into their own folder. Also renames them to remove the `pc-` or `rp-` prefixes.

Additionally renames the settings for the community plugins to remove the `pc-` prefix.