### PR TITLE
Plaintext Patching

### DIFF
--- a/src/fake_node_modules/powercord/util/debounce.js
+++ b/src/fake_node_modules/powercord/util/debounce.js
@@ -1,0 +1,11 @@
+// Credit goes to https://www.joshwcomeau.com/snippets/javascript/debounce/
+
+module.exports = (callback, wait) => {
+  let timeoutId = null;
+  return (...args) => {
+    window.clearTimeout(timeoutId);
+    timeoutId = window.setTimeout(() => {
+      callback(...args);
+    }, wait);
+  };
+};

--- a/src/fake_node_modules/powercord/util/index.js
+++ b/src/fake_node_modules/powercord/util/index.js
@@ -12,5 +12,6 @@ module.exports = {
   formatTime: require('./formatTime'),
   rmdirRf: require('./rmdirRf'),
   gotoOrJoinServer: require('./gotoOrJoinServer'),
-  injectContextMenu: require('./injectContextMenu')
+  injectContextMenu: require('./injectContextMenu'),
+  debounce: require('./debounce')
 };

--- a/src/fake_node_modules/powercord/webpack/index.js
+++ b/src/fake_node_modules/powercord/webpack/index.js
@@ -34,6 +34,7 @@ const moduleFilters = require('./modules.json');
 */
 const webpack = {
   ...require('./lazy'),
+  patchPlaintext: require('./plaintext').patchPlaintext,
 
   /**
   * Grabs a module from the Webpack store

--- a/src/fake_node_modules/powercord/webpack/lazy.js
+++ b/src/fake_node_modules/powercord/webpack/lazy.js
@@ -1,3 +1,5 @@
+const { patchModule } = require('./plaintext');
+
 /* eslint-disable callback-return */
 const listeners = new Map();
 let originalPush;
@@ -9,7 +11,7 @@ function onPush (chunk) {
   const modules = chunk[1];
 
   for (const id in modules) {
-    const mod = modules[id];
+    let mod = modules[id];
     modules[id] = function (module, exports, require) {
       try {
         mod(module, exports, require);
@@ -32,6 +34,8 @@ function onPush (chunk) {
         }
       }
     };
+
+    mod = patchModule(mod);
 
     Object.defineProperties(modules[id], {
       ...Object.getOwnPropertyDescriptors(mod),

--- a/src/fake_node_modules/powercord/webpack/plaintext.js
+++ b/src/fake_node_modules/powercord/webpack/plaintext.js
@@ -1,0 +1,98 @@
+// I would like to thank Vencord... for just existing, I heavily used it as a reference for this. -Lea
+
+const { debounce } = require('powercord/util');
+
+/**
+* @typedef RegexReplacement
+* @property {RegExp} match The regex to match
+* @property {string|function} replace Either a string or function to replace the match with
+* in the case of a function, refer to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_function_as_the_replacement
+*/
+
+/**
+* @callback PatchReplacer
+* @param {string} source The source of the module
+* @returns {string} The patched source
+*/
+
+/**
+* @typedef Patch
+* @property {string} [findModule] Only runs the replacments if a module's source contains this literal string, optional but recommended
+* @property {(PatchReplacer|RegexReplacement)[]} replacements A list of replacmenets to apply on a module
+*/
+
+// lazily required since otherwise we have a circular dependency (index -> old.webpack -> lazy -> index)
+let pcWebpack;
+
+let patchQueue = [];
+const globalPatches = [];
+
+function _patchModuleSource (mod, patches) {
+  const originalSource = mod.toString();
+
+  const patchedSource = patches.reduce((source, patch) => {
+    if (patch.findModule && !source.includes(patch.findModule)) {
+      return source;
+    }
+
+    const result = patch.replacements.reduce((source, patch) => patch(source), source);
+
+    if (result === source) {
+      return source;
+    }
+
+    return result;
+  }, originalSource);
+
+  if (patchedSource === originalSource) {
+    return mod;
+  }
+
+  // eslint-disable-next-line no-eval
+  return eval(patchedSource);
+}
+
+// We only use this in the lazy patcher. No external consumers should rely on this.
+function patchModule (mod) {
+  return _patchModuleSource(mod, globalPatches);
+}
+
+function applyPatches () {
+  const wp = pcWebpack ?? (pcWebpack = require('.'));
+
+  webpackChunkdiscord_app.forEach(c => Object.entries(c[1]).forEach(([ id, mod ]) => {
+    const patched = _patchModuleSource(mod, patchQueue);
+    if (patched === mod) {
+      return;
+    }
+
+    const cachedModule = wp.instance.cache[id];
+    if (cachedModule) {
+      patched(cachedModule, cachedModule.exports, wp.instance.require);
+    }
+
+    c[1][id] = patched;
+  }));
+
+  globalPatches.push(...patchQueue);
+  patchQueue = [];
+}
+
+const applyPatchesDebounced = debounce(applyPatches, 100);
+
+/**
+ * Applies the given patches to all currently loaded modules, as well as lazily loaded modules
+ * @param {Patch[]} patches An array of patches to apply
+ */
+function patchPlaintext (patches) {
+  patchQueue.push(...patches.map(patch => ({ ...patch,
+    replacements: patch.replacements.map(replacement => typeof replacement === 'function'
+      ? replacement
+      : (source) => source.replace(replacement.match, replacement.replace)) })));
+  applyPatchesDebounced();
+}
+
+module.exports = {
+  patchPlaintext,
+  patchModule
+};


### PR DESCRIPTION
Adds a new method (patchPlaintext) on the `powercord/webpack` API, which allows for directly patching module source code as plaintext.

Closes #181 