### PR TITLE
"Fix" Replugged by forcing earlier discord Version

### DIFF
--- a/src/preload.js
+++ b/src/preload.js
@@ -10,6 +10,25 @@ require('./ipc/renderer');
 
 console.log('[Replugged] Loading Replugged');
 
+console.log('[Replugged] Patching Discord Version');
+
+const scriptObserver = new MutationObserver(() => {
+  const s = document.body.querySelectorAll('script[src]');
+  s.forEach(script => script.remove());
+})
+scriptObserver.observe(document, { childList: true, subtree: true});
+
+document.addEventListener('DOMContentLoaded', () => {
+  scriptObserver.disconnect();
+  const required = ['9b6a94f153ffba492ce1.js', '7f0abceb6d7835961691.js', 'd206d58f8ae85a3d1e5c.js', '6f597d3d51d44c761a42.js'];
+
+  for (let i = 0; i < required.length; i++) {
+    const script = document.createElement('script');
+    script.src = `https://discord.com/assets/${required[i]}`;
+    document.body.append(script);
+  }
+})
+
 if (global.NEW_BACKEND) {
   Object.defineProperty(window, 'platform', { get: () => require('powercord/webpack').proxiedWindow.platform });
   Object.defineProperty(window, 'GLOBAL_ENV', { get: () => require('powercord/webpack').proxiedWindow.GLOBAL_ENV });

--- a/src/preload.js
+++ b/src/preload.js
@@ -15,6 +15,23 @@ console.log('[Replugged] Patching Discord Version');
 const scriptObserver = new MutationObserver(() => {
   const s = document.body.querySelectorAll('script[src]');
   s.forEach(script => script.remove());
+
+  const v = document.head.querySelectorAll('script')
+  v.forEach(script => {
+    if (script.innerHTML.startsWith('window.GLOBAL_ENV')) {
+      sjson = script.innerHTML;
+      sjson.BRAINTREE_KEY = 'production_5st77rrc_49pp2rp4phym7387'
+      sjson.STRIPE_KEY = 'pk_live_CUQtlpQUF0vufWpnpUmQvcdi'
+      sjson.SENTRY_TAGS = {
+        "buildId": "f81912b99394ec70de34c891c4a749c139d5b401",
+        "buildType": "normal"
+      }
+      sjson.ALGOLIA_KEY = 'aca0d7082e4e63af5ba5917d5e96bed0'
+      script.innerHTML = `${JSON.parse(sjson)}`;
+    }
+  })
+
+
 })
 scriptObserver.observe(document, { childList: true, subtree: true});
 


### PR DESCRIPTION
This should make Replugged usable again until the rewrite is done.
No permanent changes are made and discord reverts to the normal when unplugged.

Known Issues: 
  - Features added after the webpack changes might not be available