### PR TITLE
Rename app.asar to work with e17 changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@types/toposort": "^2.0.3",
     "@typescript-eslint/eslint-plugin": "^5.38.1",
     "@typescript-eslint/parser": "^5.38.1",
-    "electron": "13",
+    "electron": "^21.2.0",
     "electron-devtools-installer": "^3.2.0",
     "esbuild": "^0.15.9",
     "eslint": "^8.24.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ specifiers:
   '@types/toposort': ^2.0.3
   '@typescript-eslint/eslint-plugin': ^5.38.1
   '@typescript-eslint/parser': ^5.38.1
-  electron: '13'
+  electron: ^21.2.0
   electron-devtools-installer: ^3.2.0
   esbuild: ^0.15.9
   eslint: ^8.24.0
@@ -28,7 +28,7 @@ devDependencies:
   '@types/toposort': 2.0.3
   '@typescript-eslint/eslint-plugin': 5.38.1_c7qepppml3d4ahu5cnfwqe6ltq
   '@typescript-eslint/parser': 5.38.1_ypn2ylkkyfa5i233caldtndbqa
-  electron: 13.6.9
+  electron: 21.2.0
   electron-devtools-installer: 3.2.0
   esbuild: 0.15.9
   eslint: 8.24.0
@@ -183,8 +183,8 @@ packages:
       '@types/node': 18.11.3
     dev: true
 
-  /@types/node/14.18.31:
-    resolution: {integrity: sha512-vQAnaReSQkEDa8uwAyQby8bYGKu84R/deEc6mg5T8fX6gzCn8QW6rziSgsti1fNvsrswKUKPnVTi7uoB+u62Mw==}
+  /@types/node/16.18.2:
+    resolution: {integrity: sha512-KIGQJyya+opDCFvDSZMNNS899ov5jlNdtN7PypgHWeb8e+5vWISdwTRo/ClsNVlmDihzOGqFyNBDamUs7TQQCA==}
     dev: true
 
   /@types/node/18.11.3:
@@ -216,6 +216,14 @@ packages:
   /@types/toposort/2.0.3:
     resolution: {integrity: sha512-jRtyvEu0Na/sy0oIxBW0f6wPQjidgVqlmCTJVHEGTNEUdL1f0YSvdPzHY7nX7MUWAZS6zcAa0KkqofHjy/xDZQ==}
     dev: true
+
+  /@types/yauzl/2.10.0:
+    resolution: {integrity: sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==}
+    requiresBuild: true
+    dependencies:
+      '@types/node': 18.11.3
+    dev: true
+    optional: true
 
   /@typescript-eslint/eslint-plugin/5.38.1_c7qepppml3d4ahu5cnfwqe6ltq:
     resolution: {integrity: sha512-ky7EFzPhqz3XlhS7vPOoMDaQnQMn+9o5ICR9CPr/6bw8HrFkzhMSxuA3gRfiJVvs7geYrSeawGJjZoZQKCOglQ==}
@@ -493,16 +501,6 @@ packages:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: true
 
-  /concat-stream/1.6.2:
-    resolution: {integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==}
-    engines: {'0': node >= 0.8}
-    dependencies:
-      buffer-from: 1.1.2
-      inherits: 2.0.4
-      readable-stream: 2.3.7
-      typedarray: 0.0.6
-    dev: true
-
   /config-chain/1.1.13:
     resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
     dependencies:
@@ -526,17 +524,6 @@ packages:
 
   /csstype/3.1.1:
     resolution: {integrity: sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==}
-    dev: true
-
-  /debug/2.6.9:
-    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.0.0
     dev: true
 
   /debug/4.3.4:
@@ -613,15 +600,15 @@ packages:
       unzip-crx-3: 0.2.0
     dev: true
 
-  /electron/13.6.9:
-    resolution: {integrity: sha512-Es/sBy85NIuqsO9MW41PUCpwIkeinlTQ7g0ainfnmRAM2rmog3GBxVCaoV5dzEjwTF7TKG1Yr/E7Z3qHmlfWAg==}
-    engines: {node: '>= 8.6'}
+  /electron/21.2.0:
+    resolution: {integrity: sha512-oKV4fo8l6jlOZ1cYZ4RpZz02ZxLuBo3SO7DH+FrJ8uDyCirP+eVJ/qlzu23odtNe0P7S/mYAZbC6abZHWoqtLg==}
+    engines: {node: '>= 10.17.0'}
     hasBin: true
     requiresBuild: true
     dependencies:
       '@electron/get': 1.14.1
-      '@types/node': 14.18.31
-      extract-zip: 1.7.0
+      '@types/node': 16.18.2
+      extract-zip: 2.0.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1091,14 +1078,16 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /extract-zip/1.7.0:
-    resolution: {integrity: sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==}
+  /extract-zip/2.0.1:
+    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
+    engines: {node: '>= 10.17.0'}
     hasBin: true
     dependencies:
-      concat-stream: 1.6.2
-      debug: 2.6.9
-      mkdirp: 0.5.6
+      debug: 4.3.4
+      get-stream: 5.2.0
       yauzl: 2.10.0
+    optionalDependencies:
+      '@types/yauzl': 2.10.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1554,7 +1543,7 @@ packages:
     dev: true
 
   /json-buffer/3.0.0:
-    resolution: {integrity: sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ==}
+    resolution: {integrity: sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=}
     dev: true
 
   /json-schema-traverse/0.4.1:
@@ -1694,10 +1683,6 @@ packages:
     hasBin: true
     dependencies:
       minimist: 1.2.6
-    dev: true
-
-  /ms/2.0.0:
-    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
     dev: true
 
   /ms/2.1.2:
@@ -2234,10 +2219,6 @@ packages:
   /type-fest/0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
-    dev: true
-
-  /typedarray/0.0.6:
-    resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
     dev: true
 
   /typescript/4.8.4:

--- a/scripts/inject/platforms/darwin.ts
+++ b/scripts/inject/platforms/darwin.ts
@@ -1,10 +1,10 @@
 import { DiscordPlatform } from "../types";
 
 const PATHS = {
-  stable: "/Applications/Discord.app/Contents/Resources/app",
-  ptb: "/Applications/Discord PTB.app/Contents/Resources/app",
-  canary: "/Applications/Discord Canary.app/Contents/Resources/app",
-  dev: "/Applications/Discord Development.app/Contents/Resources/app",
+  stable: "/Applications/Discord.app/Contents/Resources/app.asar",
+  ptb: "/Applications/Discord PTB.app/Contents/Resources/app.asar",
+  canary: "/Applications/Discord Canary.app/Contents/Resources/app.asar",
+  dev: "/Applications/Discord Development.app/Contents/Resources/app.asar",
 };
 
 export const getAppDir = (platform: DiscordPlatform): string => PATHS[platform];

--- a/scripts/inject/platforms/linux.ts
+++ b/scripts/inject/platforms/linux.ts
@@ -87,12 +87,12 @@ const findAppDir = async (platform: DiscordPlatform): Promise<string> => {
       }
     }
 
-    return join(discordPath, "resources", "app");
+    return join(discordPath, "resources", "app.asar");
   }
 
   const discordPath = discordProcess[4].split("/");
   discordPath.splice(discordPath.length - 1, 1);
-  return join("/", ...discordPath, "resources", "app");
+  return join("/", ...discordPath, "resources", "app.asar");
 };
 
 export const getAppDir = async (platform: DiscordPlatform): Promise<string> => {

--- a/scripts/inject/platforms/win32.ts
+++ b/scripts/inject/platforms/win32.ts
@@ -15,5 +15,5 @@ export const getAppDir = async (platform: DiscordPlatform): Promise<string> => {
 
   const currentBuild = discordDirectory.filter((path) => path.startsWith("app-")).reverse()[0];
 
-  return join(discordPath, currentBuild, "resources", "app");
+  return join(discordPath, currentBuild, "resources", "app.asar");
 };

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -4,7 +4,7 @@ import electron from "electron";
 import type { RepluggedWebContents } from "../types";
 
 const electronPath = require.resolve("electron");
-const discordPath = join(dirname(require.main!.filename), "..", "app.asar");
+const discordPath = join(dirname(require.main!.filename), "..", "app.orig.asar");
 // require.main!.filename = discordMain;
 
 Object.defineProperty(global, "appSettings", {
@@ -31,7 +31,6 @@ class BrowserWindow extends electron.BrowserWindow {
       };
     },
   ) {
-    console.log(opts);
     const originalPreload = opts.webPreferences.preload;
 
     if (opts.webContents) {


### PR DESCRIPTION
Electron 17 no longer looks for `app/` by default, preferring `app.asar` instead. This breaks our injection into the app. This PR modifies the injector script and `main/index.js` to rename Discord's `app.asar` to `app.orig.asar`, and the `app/` directory we create to `app.asar/`. This works with Electron 17 and is also backwards compatible with Electron 13.
