### PR TITLE
Timeout option for webpack `waitFor`

### DIFF
--- a/src/renderer/modules/webpack.ts
+++ b/src/renderer/modules/webpack.ts
@@ -267,22 +267,19 @@ function onModule(
 
 export async function waitForModule(
   filter: Filter,
-  raw?: false,
-  options?: WaitForOptions,
+  options?: WaitForOptions & { raw?: false },
 ): Promise<ModuleExports>;
 export async function waitForModule(
   filter: Filter,
-  raw?: true,
-  options?: WaitForOptions,
+  options?: WaitForOptions & { raw?: true },
 ): Promise<RawModule>;
 
 export async function waitForModule(
   filter: Filter,
-  raw = false,
   options: WaitForOptions = {},
 ): Promise<RawModule | ModuleExports> {
   // @ts-expect-error https://github.com/microsoft/TypeScript/issues/26242
-  const existing = getModule(filter, { all: false, raw });
+  const existing = getModule(filter, { all: false, raw: options.raw });
   if (existing) {
     return Promise.resolve(existing);
   }
@@ -295,7 +292,7 @@ export async function waitForModule(
         unregister();
         resolve(mod);
       },
-      raw,
+      options.raw,
     );
   });
 

--- a/src/types/webpack.ts
+++ b/src/types/webpack.ts
@@ -28,3 +28,7 @@ export interface GetModuleOptions {
   all?: boolean;
   raw?: boolean;
 }
+
+export interface WaitForOptions {
+  timeout?: number;
+}

--- a/src/types/webpack.ts
+++ b/src/types/webpack.ts
@@ -30,5 +30,6 @@ export interface GetModuleOptions {
 }
 
 export interface WaitForOptions {
+  raw?: boolean;
   timeout?: number;
 }


### PR DESCRIPTION
Add timeout option to the webpack `waitFor` function. Will throw if nothing is returned before the specified duration.
Usage:
```js
webpack.waitForModule(YOUR_FILTER_HERE, { timeout: 1_000 });
```

The `raw` parameter has been moved to the options object. I tested that the timeout works as expected and the type definitions are still correct.