### PR TITLE
Support plugin css

### DIFF
--- a/src/renderer/managers/plugins.ts
+++ b/src/renderer/managers/plugins.ts
@@ -1,4 +1,5 @@
 // btw, pluginID is the directory name, not the RDNN. We really need a better name for this.
+import { loadStyleSheet } from "../util";
 import { RepluggedPlugin } from "../../types";
 import { Injector } from "../modules/injector";
 import { Logger, error, log } from "../modules/logger";
@@ -50,14 +51,10 @@ export async function load(plugin: RepluggedPlugin): Promise<void> {
     start: async (): Promise<void> => {
       await renderer.start?.(pluginWrapper.context);
 
-      const e = document.createElement("link");
-      e.rel = "stylesheet";
-      e.href = `replugged://plugin/${plugin.path}/${plugin.manifest.renderer?.replace(
-        /\.js$/,
-        ".css",
-      )}`;
-      styleElements.set(plugin.path, e);
-      document.head.appendChild(e);
+      const el = loadStyleSheet(
+        `replugged://plugin/${plugin.path}/${plugin.manifest.renderer?.replace(/\.js$/, ".css")}`,
+      );
+      styleElements.set(plugin.path, el);
 
       log("Plugin", plugin.manifest.name, void 0, "Plugin started");
     },

--- a/src/renderer/managers/quick-css.ts
+++ b/src/renderer/managers/quick-css.ts
@@ -1,11 +1,12 @@
-const quickCSSElement = document.createElement("link");
-quickCSSElement.rel = "stylesheet";
-quickCSSElement.href = "replugged://quickcss/main.css";
+import { loadStyleSheet } from "../util";
+
+let el: HTMLLinkElement | undefined;
 
 export function load(): void {
-  document.head.appendChild(quickCSSElement);
+  el = loadStyleSheet("replugged://quickcss/main.css");
 }
 
 export function unload(): void {
-  quickCSSElement.remove();
+  el?.remove();
+  el = void 0;
 }

--- a/src/renderer/managers/themes.ts
+++ b/src/renderer/managers/themes.ts
@@ -1,3 +1,4 @@
+import { loadStyleSheet } from "../util";
 import { Theme } from "../../types/addon";
 
 const themeElements = new Map<string, HTMLLinkElement>();
@@ -38,13 +39,10 @@ export function load(themeName: string): void {
     throw new Error(`Theme not found: ${themeName}`);
   }
   unload(themeName);
+
   const theme = themes.get(themeName)!;
-  const e = document.createElement("link");
-  e.rel = "stylesheet";
-  // This will need to change a little bit for the splash screen
-  e.href = `replugged://theme/${themeName}/${theme.main}`;
-  themeElements.set(themeName, e);
-  document.head.appendChild(e);
+  const el = loadStyleSheet(`replugged://theme/${themeName}/${theme.main}`);
+  themeElements.set(themeName, el);
 }
 
 /**

--- a/src/renderer/util.ts
+++ b/src/renderer/util.ts
@@ -1,0 +1,13 @@
+/**
+ * Loads a stylesheet into the document
+ * @param path Path to the stylesheet
+ * @returns Link element
+ */
+export const loadStyleSheet = (path: string): HTMLLinkElement => {
+  const el = document.createElement("link");
+  el.rel = "stylesheet";
+  el.href = path;
+  document.head.appendChild(el);
+
+  return el;
+};


### PR DESCRIPTION
Plugins can now use CSS files. ESBuild automatically exports them with the same name as the renderer, so they can just be imported similar to themes.