### PR TITLE
feat/fix: Add `forceUpdateElement` utility method and resolve reload crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@types/node": "^18.8.0",
     "@types/react": "^18.0.21",
     "@types/react-dom": "^18.0.10",
+    "@types/react-reconciler": "^0.28.1",
     "@types/toposort": "^2.0.3",
     "@typescript-eslint/eslint-plugin": "^5.38.1",
     "@typescript-eslint/parser": "^5.38.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ specifiers:
   '@types/node': ^18.8.0
   '@types/react': ^18.0.21
   '@types/react-dom': ^18.0.10
+  '@types/react-reconciler': ^0.28.1
   '@types/toposort': ^2.0.3
   '@typescript-eslint/eslint-plugin': ^5.38.1
   '@typescript-eslint/parser': ^5.38.1
@@ -38,6 +39,7 @@ devDependencies:
   '@types/node': 18.11.3
   '@types/react': 18.0.21
   '@types/react-dom': 18.0.10
+  '@types/react-reconciler': 0.28.1
   '@types/toposort': 2.0.3
   '@typescript-eslint/eslint-plugin': 5.38.1_c7qepppml3d4ahu5cnfwqe6ltq
   '@typescript-eslint/parser': 5.38.1_ypn2ylkkyfa5i233caldtndbqa
@@ -869,6 +871,12 @@ packages:
 
   /@types/react-dom/18.0.10:
     resolution: {integrity: sha512-E42GW/JA4Qv15wQdqJq8DL4JhNpB3prJgjgapN3qJT9K2zO5IIAQh4VXvCEDupoqAwnz0cY4RlXeC/ajX5SFHg==}
+    dependencies:
+      '@types/react': 18.0.21
+    dev: true
+
+  /@types/react-reconciler/0.28.1:
+    resolution: {integrity: sha512-ExBHUBykCcDh0HqqlJb6BA1yNpvW2iluIThK9tr1CX2tRMe3HeLt5/ow/bTpKGWoRBE5v/ISXFyjbnHRSKT6ng==}
     dependencies:
       '@types/react': 18.0.21
     dev: true

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -61,7 +61,10 @@ class BrowserWindow extends electron.BrowserWindow {
   }
 }
 
-Object.defineProperty(BrowserWindow, "name", { value: "BrowserWindow", configurable: true });
+Object.defineProperty(BrowserWindow, "name", {
+  value: "BrowserWindow",
+  configurable: true,
+});
 
 const electronExports: typeof electron = new Proxy(electron, {
   get(target, prop) {
@@ -93,7 +96,7 @@ electron.protocol.registerSchemesAsPrivileged([
   {
     scheme: "replugged",
     privileges: {
-      bypassCSP: true,
+      // bypassCSP: true,
       standard: true,
       secure: true,
       allowServiceWorkers: true,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -96,7 +96,6 @@ electron.protocol.registerSchemesAsPrivileged([
   {
     scheme: "replugged",
     privileges: {
-      // bypassCSP: true,
       standard: true,
       secure: true,
       allowServiceWorkers: true,

--- a/src/renderer/util.ts
+++ b/src/renderer/util.ts
@@ -1,3 +1,5 @@
+import { Fiber } from "react-reconciler";
+
 /**
  * Loads a stylesheet into the document
  * @param path Path to the stylesheet
@@ -10,11 +12,6 @@ export const loadStyleSheet = (path: string): HTMLLinkElement => {
   document.head.appendChild(el);
 
   return el;
-};
-
-export type ReactFiber<T extends Record<string, unknown> = Record<string, unknown>> = T & {
-  stateNode: Element | T;
-  return: ReactFiber<T>;
 };
 
 /**
@@ -38,9 +35,7 @@ export async function waitFor(selector: string): Promise<Element> {
  * @returns React instance
  * @throws If the React instance could not be found
  */
-export function getReactInstance<T extends Record<string, unknown> = Record<string, unknown>>(
-  element: Element,
-): ReactFiber<T> {
+export function getReactInstance(element: Element): Fiber | null {
   const keys = Object.keys(element);
   const reactKey = keys.find((key) => key.startsWith("__reactFiber$"));
   if (!reactKey) {
@@ -56,10 +51,8 @@ export function getReactInstance<T extends Record<string, unknown> = Record<stri
  * @returns React owner instance
  * @throws If the React owner instance could not be found
  */
-export function getOwnerInstance<T extends Record<string, unknown> = Record<string, unknown>>(
-  element: Element,
-): T {
-  let current = getReactInstance<T>(element);
+export function getOwnerInstance(element: Element): React.Component & Record<string, unknown> {
+  let current = getReactInstance(element);
   while (current) {
     const owner = current.stateNode;
     if (owner && !(owner instanceof Element)) {
@@ -68,4 +61,17 @@ export function getOwnerInstance<T extends Record<string, unknown> = Record<stri
     current = current.return;
   }
   throw new Error("Could not find react owner");
+}
+
+/**
+ * Force updates a rendered React component by its DOM selector
+ * @param selector The DOM selector to force update
+ * @param all Whether all elements matching that selector should be force updated
+ */
+export function forceUpdateElement(selector: string, all = false): void {
+  const elements = (
+    all ? [...document.querySelectorAll(selector)] : [document.querySelector(selector)]
+  ).filter(Boolean) as Element[];
+
+  elements.forEach((element) => getOwnerInstance(element)?.forceUpdate());
 }


### PR DESCRIPTION
### Proposed Changes:
- Add `forceUpdateElement` utility method (closes #315)
    - I've added `@types/react-reconciler` as a dependency to make use of an actual type for `Fiber`. 
- Resolve crash on reload (closes #291)
    - Enforcing `bypassCSP` on a registered privileged scheme is the cause of this.