### PR TITLE
create confirm modal

### DIFF
--- a/src/renderer/modules/components/Button.tsx
+++ b/src/renderer/modules/components/Button.tsx
@@ -63,14 +63,15 @@ export const ButtonItem = (props: React.PropsWithChildren<ButtonItemProps>) => {
               )}
             </Tooltip>
           )}
-          {!props.tooltipText &&
+          {!props.tooltipText && (
             <Button
               color={props.success ? Button.Colors.GREEN : props.color || Button.Colors.BRAND}
               disabled={props.disabled}
               onClick={() => props.onClick()}
               style={{ marginLeft: 5, position: "absolute", right: "7%" }}>
               {props.button}
-            </Button>}
+            </Button>
+          )}
         </div>
         <Divider className={classes.dividerDefault} />
       </FormItem>

--- a/src/renderer/modules/components/Button.tsx
+++ b/src/renderer/modules/components/Button.tsx
@@ -63,6 +63,14 @@ export const ButtonItem = (props: React.PropsWithChildren<ButtonItemProps>) => {
               )}
             </Tooltip>
           )}
+          {!props.tooltipText &&
+            <Button
+              color={props.success ? Button.Colors.GREEN : props.color || Button.Colors.BRAND}
+              disabled={props.disabled}
+              onClick={() => props.onClick()}
+              style={{ marginLeft: 5, position: "absolute", right: "7%" }}>
+              {props.button}
+            </Button>}
         </div>
         <Divider className={classes.dividerDefault} />
       </FormItem>

--- a/src/renderer/util.tsx
+++ b/src/renderer/util.tsx
@@ -90,12 +90,12 @@ export type ConfirmModalProps = {
 
 export function createConfirmModal(props: ConfirmModalProps): Promise<boolean> {
   let modalKey: string;
-  
+
   return new Promise((resolve, _) => {
     modalKey = modal.openModal((p: ModalProps) => (
       <Modal.ModalRoot {...p}>
         <Modal.ModalHeader>
-          <FormText.DEFAULT style={{fontSize: '30px'}}>{props.title}</FormText.DEFAULT>
+          <FormText.DEFAULT style={{ fontSize: "30px" }}>{props.title}</FormText.DEFAULT>
         </Modal.ModalHeader>
         <Modal.ModalContent>
           <FormText.DEFAULT>{props.note}</FormText.DEFAULT>

--- a/src/renderer/util.tsx
+++ b/src/renderer/util.tsx
@@ -1,4 +1,7 @@
 import { Fiber } from "react-reconciler";
+import { ModalProps } from "./modules/components/Modal";
+import { Button, FormText, Modal } from "./modules/components";
+import { modal } from "@common";
 
 /**
  * Loads a stylesheet into the document
@@ -74,4 +77,51 @@ export function forceUpdateElement(selector: string, all = false): void {
   ).filter(Boolean) as Element[];
 
   elements.forEach((element) => getOwnerInstance(element)?.forceUpdate());
+}
+
+export type ConfirmModalProps = {
+  onCancel?: () => unknown;
+  onConfirm: () => unknown;
+  title: string;
+  note?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+};
+
+export function createConfirmModal(props: ConfirmModalProps): Promise<boolean> {
+  let modalKey: string;
+  
+  return new Promise((resolve, _) => {
+    modalKey = modal.openModal((p: ModalProps) => (
+      <Modal.ModalRoot {...p}>
+        <Modal.ModalHeader>
+          <FormText.DEFAULT style={{fontSize: '30px'}}>{props.title}</FormText.DEFAULT>
+        </Modal.ModalHeader>
+        <Modal.ModalContent>
+          <FormText.DEFAULT>{props.note}</FormText.DEFAULT>
+        </Modal.ModalContent>
+        <Modal.ModalFooter>
+          <Button
+            color={Button.Colors.TRANSPARENT}
+            look={Button.Looks.LINK}
+            onClick={() => {
+              props.onCancel?.();
+              modal.closeModal(modalKey);
+              resolve(false);
+            }}>
+            {props.cancelLabel ?? "Cancel"}
+          </Button>
+          <Button
+            color={Button.Colors.GREEN}
+            onClick={() => {
+              props.onConfirm();
+              modal.closeModal(modalKey);
+              resolve(true);
+            }}>
+            {props.confirmLabel ?? "Confirm"}
+          </Button>
+        </Modal.ModalFooter>
+      </Modal.ModalRoot>
+    ));
+  });
 }


### PR DESCRIPTION
Closes #323 

You can use this to quick test it if you want

```jsx
<ButtonItem
  note="omggg"
  button="click me"
  onClick={async () => {
    const result = await createConfirmModal({
      title: "let's see",
      note: "cool",
      onConfirm: () => console.log('confirmmeddd woohooo'),
      onCancel: () => console.log('cancelled aw'),
    });
    console.log("omg after promise", result);
  }}
>tittlee</ButtonItem>
```