### PR TITLE
Make addon version number smaller

### DIFF
--- a/src/renderer/coremods/settings/pages/Addons.tsx
+++ b/src/renderer/coremods/settings/pages/Addons.tsx
@@ -232,11 +232,11 @@ function Card({
           <Text variant="heading-sm/normal" tag="h2" color="header-secondary">
             <Text variant="heading-lg/bold" tag="span">
               {addon.manifest.name}
-            </Text>{" "}
-            <Text variant="heading-lg/normal" tag="span">
-              v{addon.manifest.version}
             </Text>
-            <span> by </span>
+            <span>
+              {" "}
+              <b>v{addon.manifest.version}</b> by{" "}
+            </span>
             <Authors addon={addon} />
           </Text>
         </span>


### PR DESCRIPTION
Per feedback in Discord
<img width="682" alt="Screenshot on 2023-01-16 at 12 50 39" src="https://user-images.githubusercontent.com/14863373/212748593-4016e206-de40-49c6-9b12-220ca06a5d0a.png">
