### PR TITLE
remove text-transform from addon card title

### DIFF
--- a/src/renderer/coremods/settings/pages/Addons.tsx
+++ b/src/renderer/coremods/settings/pages/Addons.tsx
@@ -245,7 +245,7 @@ function Card({
         style={{ gap: "15px", marginBottom: "15px" }}>
         <span>
           <Text variant="heading-sm/normal" tag="h2" color="header-secondary">
-            <Text variant="heading-lg/bold" tag="span" style={{ textTransform: "capitalize" }}>
+            <Text variant="heading-lg/bold" tag="span">
               {addon.manifest.name}
             </Text>
             <span>


### PR DESCRIPTION
does what the title says.
it was messing up the titles of plugins that are intended to be lowercase; if the plugin name should be Title Case, the author can just set it as such in the manifest.