### PR TITLE
Radio and RadioItem Component

### DIFF
--- a/src/renderer/modules/components/RadioItem.tsx
+++ b/src/renderer/modules/components/RadioItem.tsx
@@ -1,0 +1,61 @@
+import type { ObjectExports } from "../../../types";
+import { filters, getFunctionBySource, waitForModule } from "../webpack";
+import { Divider, FormItem, FormText, Text } from ".";
+
+type OptionType = {
+  name: string;
+  value: string;
+  desc?: string;
+  disabled?: boolean;
+  color?: string;
+  icon?: string;
+  tooltipText?: string;
+  tooltipPosition?: "top" | "bottom" | "left" | "right" | "center";
+};
+
+interface RadioProps {
+  options: OptionType[];
+  value: string;
+  onChange: (e: OptionType) => void;
+  disabled?: boolean;
+  size?: string;
+  radioPosition?: "left" | "right";
+  withTransparentBackground?: boolean;
+  className?: string;
+  itemInfoClassName?: string;
+  itemTitleClassName?: string;
+  radioItemClassName?: string;
+  radioItemIconClassName?: string;
+  collapsibleClassName?: string;
+}
+
+export type RadioType = React.ComponentType<RadioProps> & {
+  Sizes: Record<"NOT_SET" | "NONE" | "SMALL" | "MEDIUM", string>;
+};
+
+const radioStr = ".itemInfoClassName";
+
+export const Radio = (await waitForModule(filters.bySource(radioStr)).then((mod) =>
+  getFunctionBySource(radioStr, mod as ObjectExports),
+)) as RadioType;
+
+const classes = (await waitForModule(filters.byProps("labelRow"))) as Record<string, string>;
+
+interface RadioItemProps extends RadioProps {
+  note?: string;
+}
+
+export type RadioItemType = React.FC<React.PropsWithChildren<RadioItemProps>>;
+
+export const RadioItem = (props: React.PropsWithChildren<RadioItemProps>) => {
+  return (
+    <div style={{ marginBottom: 20 }}>
+      <FormItem>
+        <Text.Eyebrow style={{ marginBottom: 8 }}>{props.children}</Text.Eyebrow>
+        <FormText.DESCRIPTION style={{ marginBottom: 8 }}>{props.note}</FormText.DESCRIPTION>
+        {<Radio {...props}></Radio>}
+        <Divider className={classes.dividerDefault} />
+      </FormItem>
+    </div>
+  );
+};

--- a/src/renderer/modules/components/RadioItem.tsx
+++ b/src/renderer/modules/components/RadioItem.tsx
@@ -8,14 +8,13 @@ type OptionType = {
   desc?: string;
   disabled?: boolean;
   color?: string;
-  icon?: string;
   tooltipText?: string;
   tooltipPosition?: "top" | "bottom" | "left" | "right" | "center";
 };
 
 interface RadioProps {
   options: OptionType[];
-  value: string;
+  value?: string;
   onChange: (e: OptionType) => void;
   disabled?: boolean;
   size?: string;
@@ -25,8 +24,6 @@ interface RadioProps {
   itemInfoClassName?: string;
   itemTitleClassName?: string;
   radioItemClassName?: string;
-  radioItemIconClassName?: string;
-  collapsibleClassName?: string;
 }
 
 export type RadioType = React.ComponentType<RadioProps> & {

--- a/src/renderer/modules/components/index.ts
+++ b/src/renderer/modules/components/index.ts
@@ -42,6 +42,15 @@ export type { SwitchItemType };
 export let SwitchItem: SwitchItemType;
 importTimeout("SwitchItem", import("./SwitchItem"), (mod) => (SwitchItem = mod.SwitchItem));
 
+import { type RadioItemType, RadioType } from "./RadioItem";
+export type { RadioType };
+export let Radio: RadioType;
+importTimeout("RadioItem", import("./RadioItem"), (mod) => (Radio = mod.Radio));
+
+export type { RadioItemType };
+export let RadioItem: RadioItemType;
+importTimeout("RadioItem", import("./RadioItem"), (mod) => (RadioItem = mod.RadioItem));
+
 import type { ModalType } from "./Modal";
 export type { ModalType };
 export let Modal: ModalType;


### PR DESCRIPTION
Adds a `Radio` component (just the radio group) and a `RadioItem` which includes a title and note.

Example:
```tsx
<RadioItem
  note="Note placeholder."
  options={[
    { name: "Option 1", value: "opt1" },
    {
      name: "Option 2",
      value: "opt2",
      desc: "Description placeholder.",
    },
    {
      name: "Option 3 (colored)",
      value: "opt3",
      color: "#f4907f",
    },
    {
      name: "Option 4 (disabled)",
      value: "opt4",
      disabled: true,
      tooltipText: "Tooltip placeholder",
      tooltipPosition: "bottom",
    },
  ]}
  onChange={(e) => {
    setSelected(e.value);
  }}
  value={selected}
  size={Radio.Sizes.MEDIUM}>
  Title Placeholder
</RadioItem>
```

![image](https://user-images.githubusercontent.com/38290480/215838841-ab6d9a86-1f52-4d0e-8a25-e40a4ac47e22.png)

Closes: #354 