### PR TITLE
Fix FormItem, ButtonItem and Category

### DIFF
--- a/src/renderer/modules/components/Button.tsx
+++ b/src/renderer/modules/components/Button.tsx
@@ -1,7 +1,7 @@
 import { filters, waitForModule } from "../webpack";
 import type { ReactComponent } from "../../../types/util";
 import type React from "react";
-import { Divider, Flex, FormItem, FormText, Tooltip } from ".";
+import { Divider, Flex, FormText, Tooltip } from ".";
 import type { ObjectExports } from "../../../types";
 
 export type ButtonType = ReactComponent<{
@@ -52,35 +52,38 @@ interface ButtonItemProps {
 export type ButtonItemType = React.FC<React.PropsWithChildren<ButtonItemProps>>;
 
 export const ButtonItem = (props: React.PropsWithChildren<ButtonItemProps>): React.ReactElement => {
+  const button = (
+    <Button
+      color={props.success ? Button.Colors.GREEN : props.color || Button.Colors.BRAND}
+      disabled={props.disabled}
+      onClick={() => props.onClick()}>
+      {props.button}
+    </Button>
+  );
+
   return (
-    <div
-      className={`${Flex.Direction.VERTICAL} ${Flex.Justify.START} ${Flex.Align.STRETCH} ${Flex.Wrap.NO_WRAP}`}
-      style={{ marginBottom: 20 }}>
-      <FormItem>
-        <div style={{ cursor: "pointer", alignItems: "center", display: "flex" }}>
-          <div>
-            <div className={classes.labelRow}>
-              <label className={classes.title}>{props.children}</label>
-            </div>
-            <FormText.DESCRIPTION className={classes.note}>{props.note}</FormText.DESCRIPTION>
+    <div style={{ marginBottom: 20 }}>
+      <Flex justify={Flex.Justify.END}>
+        <Flex.Child>
+          <div className={classes.labelRow}>
+            <label className={classes.title}>{props.children}</label>
+            {props.tooltipText ? (
+              <Tooltip
+                text={props.tooltipText}
+                position={props.tooltipPosition}
+                shouldShow={Boolean(props.tooltipText)}
+                className={Flex.Align.CENTER}
+                style={{ height: "100%" }}>
+                {button}
+              </Tooltip>
+            ) : (
+              button
+            )}
           </div>
-          {props.tooltipText && (
-            <Tooltip
-              text={props.tooltipText}
-              position={props.tooltipPosition}
-              shouldShow={Boolean(props.tooltipText)}>
-              <Button
-                color={props.success ? Button.Colors.GREEN : props.color || Button.Colors.BRAND}
-                disabled={props.disabled}
-                onClick={() => props.onClick()}
-                style={{ marginLeft: 5, position: "absolute", right: "7%" }}>
-                {props.button}
-              </Button>
-            </Tooltip>
-          )}
-        </div>
-        <Divider className={classes.dividerDefault} />
-      </FormItem>
+          <FormText.DESCRIPTION className={classes.note}>{props.note}</FormText.DESCRIPTION>
+        </Flex.Child>
+      </Flex>
+      <Divider className={classes.dividerDefault} />
     </div>
   );
 };

--- a/src/renderer/modules/components/Category.tsx
+++ b/src/renderer/modules/components/Category.tsx
@@ -1,5 +1,5 @@
 import { filters, waitForModule } from "../webpack";
-import { Divider, Flex, FormItem, FormText } from ".";
+import { Divider, Flex, FormText } from ".";
 import React from "@common/react";
 import type { ObjectExports } from "../../../types";
 
@@ -15,7 +15,7 @@ interface CategoryProps {
   onChange?: () => void;
 }
 
-export type CategoryType = React.FC<CategoryProps>;
+export type CategoryType = React.FC<React.PropsWithChildren<CategoryProps>>;
 
 /**
  * A category. It's opened state, by default, is automatically handled by the component. `open` and `onChange` both must be specified to override.
@@ -31,50 +31,47 @@ export default ((props: React.PropsWithChildren<CategoryProps>) => {
   };
 
   return (
-    <div
-      className={`${Flex.Direction.VERTICAL} ${Flex.Justify.START} ${Flex.Align.STRETCH} ${Flex.Wrap.NO_WRAP}`}>
-      <FormItem>
-        <div
-          style={{ cursor: "pointer", alignItems: "center", display: "flex" }}
-          onClick={() => {
-            handleClick();
+    <div style={{ marginBottom: 20 }}>
+      <div
+        style={{ cursor: "pointer", alignItems: "center", display: "flex" }}
+        onClick={() => {
+          handleClick();
+        }}>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          style={{
+            width: 28,
+            height: 28,
+            marginRight: 15,
+            transition: "transform 0.3s",
+            transform: open ? "rotate(90deg)" : undefined,
           }}>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            style={{
-              width: 28,
-              height: 28,
-              marginRight: 15,
-              transition: "transform 0.3s",
-              transform: open ? "rotate(90deg)" : undefined,
-            }}>
-            <path
-              fill="var(--header-primary)"
-              d="M9.29 15.88L13.17 12 9.29 8.12c-.39-.39-.39-1.02 0-1.41.39-.39 1.02-.39 1.41 0l4.59 4.59c.39.39.39 1.02 0 1.41L10.7 17.3c-.39.39-1.02.39-1.41 0-.38-.39-.39-1.03 0-1.42z"
-            />
-          </svg>
-          <div>
-            <div className={classes.labelRow}>
-              <label className={classes.title}>{props.title}</label>
-            </div>
-            <FormText.DESCRIPTION className={classes.note}>{props.note}</FormText.DESCRIPTION>
+          <path
+            fill="var(--header-primary)"
+            d="M9.29 15.88L13.17 12 9.29 8.12c-.39-.39-.39-1.02 0-1.41.39-.39 1.02-.39 1.41 0l4.59 4.59c.39.39.39 1.02 0 1.41L10.7 17.3c-.39.39-1.02.39-1.41 0-.38-.39-.39-1.03 0-1.42z"
+          />
+        </svg>
+        <div style={{ flex: 1 }}>
+          <div className={classes.labelRow}>
+            <label className={classes.title}>{props.title}</label>
           </div>
+          <FormText.DESCRIPTION className={classes.note}>{props.note}</FormText.DESCRIPTION>
         </div>
-        {open ? (
-          <div
-            style={{
-              marginTop: 20,
-              marginLeft: 12,
-              borderLeft: "1px var(--background-modifier-accent) solid",
-              paddingLeft: 33,
-            }}>
-            {props.children}
-          </div>
-        ) : (
-          <Divider className={classes.dividerDefault} />
-        )}
-      </FormItem>
+      </div>
+      {open ? (
+        <div
+          style={{
+            marginTop: 20,
+            marginLeft: 12,
+            borderLeft: "1px var(--background-modifier-accent) solid",
+            paddingLeft: 33,
+          }}>
+          {props.children}
+        </div>
+      ) : (
+        <Divider className={classes.dividerDefault} />
+      )}
     </div>
   );
 }) as CategoryType;

--- a/src/renderer/modules/components/Category.tsx
+++ b/src/renderer/modules/components/Category.tsx
@@ -1,5 +1,5 @@
 import { filters, waitForModule } from "../webpack";
-import { Divider, Flex, FormText } from ".";
+import { Divider, FormText } from ".";
 import React from "@common/react";
 import type { ObjectExports } from "../../../types";
 

--- a/src/renderer/modules/components/FormItem.tsx
+++ b/src/renderer/modules/components/FormItem.tsx
@@ -1,17 +1,21 @@
-import type { ObjectExports, ReactComponent } from "../../../types";
-import { filters, getFunctionBySource, waitForModule } from "../webpack";
-
-const mod = await waitForModule(filters.bySource("=/^((?:rgb|hsl)a?)\\s*\\(([^)]*)\\)/i;"));
-const FormItemComp = getFunctionBySource("FocusRing", mod as ObjectExports) as ReactComponent<{
-  children: React.ReactNode;
-}>;
+import type { ReactComponent } from "../../../types";
+import { filters, waitForModule } from "../webpack";
 
 export type FormItemType = ReactComponent<{
   children: React.ReactNode;
+  title?: React.ReactNode;
+  error?: React.ReactNode;
+  disabled?: boolean;
+  required?: boolean;
+  tag?: "h1" | "h2" | "h3" | "h4" | "h5" | "label" | "legend";
+  style?: React.CSSProperties;
+  className?: string;
+  titleClassName?: string;
 }>;
-// Fragment because FormItem can only have one child.
-export default ((props) => (
-  <FormItemComp {...props}>
-    <>{props.children}</>
-  </FormItemComp>
+
+const formItemStr =
+  '"children","disabled","className","titleClassName","tag","required","style","title","error"';
+
+export const FormItem = (await waitForModule(filters.bySource(formItemStr)).then((mod) =>
+  Object.values(mod).find((x) => x?.render?.toString()?.includes(formItemStr)),
 )) as FormItemType;

--- a/src/renderer/modules/components/FormItem.tsx
+++ b/src/renderer/modules/components/FormItem.tsx
@@ -1,7 +1,8 @@
 import type { ReactComponent } from "../../../types";
 import { filters, waitForModule } from "../webpack";
+import { Divider, FormText } from ".";
 
-export type FormItemType = ReactComponent<{
+interface FormItemCompProps {
   children: React.ReactNode;
   title?: React.ReactNode;
   error?: React.ReactNode;
@@ -11,11 +12,37 @@ export type FormItemType = ReactComponent<{
   style?: React.CSSProperties;
   className?: string;
   titleClassName?: string;
-}>;
+}
 
 const formItemStr =
   '"children","disabled","className","titleClassName","tag","required","style","title","error"';
 
-export const FormItem = (await waitForModule(filters.bySource(formItemStr)).then((mod) =>
+const FormItemComp = await waitForModule(filters.bySource(formItemStr)).then((mod) =>
   Object.values(mod).find((x) => x?.render?.toString()?.includes(formItemStr)),
-)) as FormItemType;
+);
+
+const classes = await waitForModule<Record<"dividerDefault", string>>(filters.byProps("labelRow"));
+
+interface FormItemProps extends FormItemCompProps {
+  note?: string;
+  notePosition?: "before" | "after";
+  divider?: boolean;
+}
+
+export type FormItemType = ReactComponent<FormItemProps>;
+
+export default ((props) => {
+  if (!props.notePosition) props.notePosition = "before";
+  return (
+    <FormItemComp {...props}>
+      {props.note && props.notePosition === "before" && (
+        <FormText.DESCRIPTION style={{ marginBottom: 8 }}>{props.note}</FormText.DESCRIPTION>
+      )}
+      {props.children}
+      {props.note && props.notePosition === "after" && (
+        <FormText.DESCRIPTION style={{ marginTop: 8 }}>{props.note}</FormText.DESCRIPTION>
+      )}
+      {props.divider && <Divider className={classes.dividerDefault} />}
+    </FormItemComp>
+  );
+}) as FormItemType;

--- a/src/renderer/modules/components/RadioItem.tsx
+++ b/src/renderer/modules/components/RadioItem.tsx
@@ -1,6 +1,6 @@
 import type { ObjectExports } from "../../../types";
 import { filters, getFunctionBySource, waitForModule } from "../webpack";
-import { Divider, FormItem, FormText } from ".";
+import { FormItem } from ".";
 
 interface RadioOptionType {
   name: string;
@@ -37,8 +37,6 @@ export const Radio = (await waitForModule(filters.bySource(radioStr)).then((mod)
   getFunctionBySource(radioStr, mod as ObjectExports),
 )) as RadioType;
 
-const classes = await waitForModule<Record<"dividerDefault", string>>(filters.byProps("labelRow"));
-
 interface RadioItemProps extends RadioProps {
   note?: string;
 }
@@ -47,10 +45,13 @@ export type RadioItemType = React.FC<React.PropsWithChildren<RadioItemProps>>;
 
 export const RadioItem = (props: React.PropsWithChildren<RadioItemProps>): React.ReactElement => {
   return (
-    <FormItem title={props.children} style={{ marginBottom: 20 }}>
-      <FormText.DESCRIPTION style={{ marginBottom: 8 }}>{props.note}</FormText.DESCRIPTION>
+    <FormItem
+      title={props.children}
+      style={{ marginBottom: 20 }}
+      note={props.note}
+      notePosition="before"
+      divider>
       <Radio {...props}></Radio>
-      <Divider className={classes.dividerDefault} />
     </FormItem>
   );
 };

--- a/src/renderer/modules/components/RadioItem.tsx
+++ b/src/renderer/modules/components/RadioItem.tsx
@@ -1,6 +1,6 @@
 import type { ObjectExports } from "../../../types";
 import { filters, getFunctionBySource, waitForModule } from "../webpack";
-import { Divider, FormItem, FormText, Text } from ".";
+import { Divider, FormItem, FormText } from ".";
 
 interface RadioOptionType {
   name: string;
@@ -47,13 +47,10 @@ export type RadioItemType = React.FC<React.PropsWithChildren<RadioItemProps>>;
 
 export const RadioItem = (props: React.PropsWithChildren<RadioItemProps>): React.ReactElement => {
   return (
-    <div style={{ marginBottom: 20 }}>
-      <FormItem>
-        <Text.Eyebrow style={{ marginBottom: 8 }}>{props.children}</Text.Eyebrow>
-        <FormText.DESCRIPTION style={{ marginBottom: 8 }}>{props.note}</FormText.DESCRIPTION>
-        <Radio {...props}></Radio>
-        <Divider className={classes.dividerDefault} />
-      </FormItem>
-    </div>
+    <FormItem title={props.children} style={{ marginBottom: 20 }}>
+      <FormText.DESCRIPTION style={{ marginBottom: 8 }}>{props.note}</FormText.DESCRIPTION>
+      <Radio {...props}></Radio>
+      <Divider className={classes.dividerDefault} />
+    </FormItem>
   );
 };

--- a/src/renderer/modules/components/SelectItem.tsx
+++ b/src/renderer/modules/components/SelectItem.tsx
@@ -1,6 +1,6 @@
 import type { ObjectExports } from "../../../types";
 import { filters, getFunctionBySource, waitForModule } from "../webpack";
-import { Divider, FormItem, FormText, Text } from ".";
+import { Divider, FormItem, FormText } from ".";
 
 interface SelectOptionType {
   label: string;
@@ -76,13 +76,10 @@ export type SelectItemType = React.FC<React.PropsWithChildren<SelectItemProps>>;
 
 export const SelectItem = (props: React.PropsWithChildren<SelectItemProps>): React.ReactElement => {
   return (
-    <div style={{ marginBottom: 20 }}>
-      <FormItem>
-        <Text.Eyebrow style={{ marginBottom: 8 }}>{props.children}</Text.Eyebrow>
-        <Select {...props}></Select>
-        <FormText.DESCRIPTION style={{ marginTop: 8 }}>{props.note}</FormText.DESCRIPTION>
-        <Divider className={classes.dividerDefault} />
-      </FormItem>
-    </div>
+    <FormItem title={props.children} style={{ marginBottom: 20 }}>
+      <Select {...props}></Select>
+      <FormText.DESCRIPTION style={{ marginTop: 8 }}>{props.note}</FormText.DESCRIPTION>
+      <Divider className={classes.dividerDefault} />
+    </FormItem>
   );
 };

--- a/src/renderer/modules/components/SelectItem.tsx
+++ b/src/renderer/modules/components/SelectItem.tsx
@@ -1,6 +1,6 @@
 import type { ObjectExports } from "../../../types";
 import { filters, getFunctionBySource, waitForModule } from "../webpack";
-import { Divider, FormItem, FormText } from ".";
+import { FormItem } from ".";
 
 interface SelectOptionType {
   label: string;
@@ -66,8 +66,6 @@ export const Select = ((props) => {
   );
 }) as SelectType;
 
-const classes = await waitForModule<Record<"dividerDefault", string>>(filters.byProps("labelRow"));
-
 interface SelectItemProps extends SelectProps {
   note?: string;
 }
@@ -76,10 +74,13 @@ export type SelectItemType = React.FC<React.PropsWithChildren<SelectItemProps>>;
 
 export const SelectItem = (props: React.PropsWithChildren<SelectItemProps>): React.ReactElement => {
   return (
-    <FormItem title={props.children} style={{ marginBottom: 20 }}>
+    <FormItem
+      title={props.children}
+      style={{ marginBottom: 20 }}
+      note={props.note}
+      notePosition="after"
+      divider>
       <Select {...props}></Select>
-      <FormText.DESCRIPTION style={{ marginTop: 8 }}>{props.note}</FormText.DESCRIPTION>
-      <Divider className={classes.dividerDefault} />
     </FormItem>
   );
 };

--- a/src/renderer/modules/components/index.ts
+++ b/src/renderer/modules/components/index.ts
@@ -83,7 +83,7 @@ importTimeout("FormText", import("./FormText"), (mod) => (FormText = mod.FormTex
 import type { FormItemType } from "./FormItem";
 export type { FormItemType };
 export let FormItem: FormItemType;
-importTimeout("FormItem", import("./FormItem"), (mod) => (FormItem = mod.FormItem));
+importTimeout("FormItem", import("./FormItem"), (mod) => (FormItem = mod.default));
 
 import type { ButtonItemType, ButtonType } from "./Button";
 export type { ButtonType };

--- a/src/renderer/modules/components/index.ts
+++ b/src/renderer/modules/components/index.ts
@@ -83,7 +83,7 @@ importTimeout("FormText", import("./FormText"), (mod) => (FormText = mod.FormTex
 import type { FormItemType } from "./FormItem";
 export type { FormItemType };
 export let FormItem: FormItemType;
-importTimeout("FormItem", import("./FormItem"), (mod) => (FormItem = mod.default));
+importTimeout("FormItem", import("./FormItem"), (mod) => (FormItem = mod.FormItem));
 
 import type { ButtonItemType, ButtonType } from "./Button";
 export type { ButtonType };


### PR DESCRIPTION
- Fixes `FormItem` component, with new props as well.
- Fixes `ButtonItem`, with the use of Flex. It was very messed up with centering the button.
- Fixes `Category`, added children type and doesn't break anymore if title/note is long.