### PR TITLE
Change argument order for getFunctionBySource and getFunctionKeyBySource

### DIFF
--- a/src/renderer/coremods/installer/index.tsx
+++ b/src/renderer/coremods/installer/index.tsx
@@ -58,7 +58,7 @@ async function injectLinks(): Promise<void> {
   });
   const exports = linkMod.exports as ObjectExports & Record<string, React.FC<AnchorProps>>;
 
-  const key = getFunctionKeyBySource(".useDefaultUnderlineStyles", exports);
+  const key = getFunctionKeyBySource(exports, ".useDefaultUnderlineStyles");
   if (!key) {
     logger.error("Failed to find link component.");
     return;
@@ -107,7 +107,7 @@ async function injectRpc(): Promise<void> {
   const rpcValidatorMod = await waitForModule<
     Record<string, (socket: Socket, client_id: string, origin: string) => Promise<void>>
   >(filters.bySource("Invalid Client ID"));
-  const validatorFunctionKey = getFunctionKeyBySource("Invalid Client ID", rpcValidatorMod);
+  const validatorFunctionKey = getFunctionKeyBySource(rpcValidatorMod, "Invalid Client ID");
   if (!validatorFunctionKey) {
     logger.error("Failed to find RPC validator function.");
     return;

--- a/src/renderer/modules/components/ContextMenu.tsx
+++ b/src/renderer/modules/components/ContextMenu.tsx
@@ -47,7 +47,7 @@ const rawMod = await waitForModule(filters.bySource("menuitemcheckbox"), { raw: 
 const source = sourceStrings[rawMod?.id].matchAll(/if\(\w+\.type===\w+\.(\w+)\).+?type:"(.+?)"/g);
 
 const Menu = {
-  ContextMenu: getFunctionBySource("getContainerProps", menuMod as ObjectExports),
+  ContextMenu: getFunctionBySource(menuMod as ObjectExports, "getContainerProps"),
 } as ContextMenuType;
 
 for (const [, identifier, type] of source) {

--- a/src/renderer/modules/components/Divider.tsx
+++ b/src/renderer/modules/components/Divider.tsx
@@ -7,5 +7,5 @@ const rgx = /\.divider,.\),style:./;
 
 export default (await waitForModule(filters.bySource(rgx)).then((mod) => {
   if (typeof mod === "function") return mod;
-  return getFunctionBySource(rgx, mod as ObjectExports);
+  return getFunctionBySource(mod as ObjectExports, rgx);
 })) as DividerType;

--- a/src/renderer/modules/components/FormText.tsx
+++ b/src/renderer/modules/components/FormText.tsx
@@ -3,8 +3,8 @@ import { filters, getExportsForProps, getFunctionBySource, waitForModule } from 
 
 const mod = await waitForModule(filters.bySource("LABEL_SELECTED"));
 const FormTextComp = getFunctionBySource(
-  '"type","className","disabled","selectable","children","style"',
   mod as ObjectExports,
+  '"type","className","disabled","selectable","children","style"',
 ) as ReactComponent<{ type: string }>;
 const types = getExportsForProps(mod, ["LABEL_SELECTED"])!;
 

--- a/src/renderer/modules/components/Modal.tsx
+++ b/src/renderer/modules/components/Modal.tsx
@@ -45,9 +45,9 @@ export interface ModalType {
 const mod = await waitForModule(filters.bySource("().closeWithCircleBackground"));
 
 export default {
-  ModalRoot: getFunctionBySource("().root", mod as ObjectExports),
-  ModalHeader: getFunctionBySource("().header", mod as ObjectExports),
-  ModalContent: getFunctionBySource("().content", mod as ObjectExports),
-  ModalFooter: getFunctionBySource("().footerSeparator", mod as ObjectExports),
-  ModalCloseButton: getFunctionBySource("().closeWithCircleBackground", mod as ObjectExports),
+  ModalRoot: getFunctionBySource(mod as ObjectExports, "().root"),
+  ModalHeader: getFunctionBySource(mod as ObjectExports, "().header"),
+  ModalContent: getFunctionBySource(mod as ObjectExports, "().content"),
+  ModalFooter: getFunctionBySource(mod as ObjectExports, "().footerSeparator"),
+  ModalCloseButton: getFunctionBySource(mod as ObjectExports, "().closeWithCircleBackground"),
 } as ModalType;

--- a/src/renderer/modules/components/RadioItem.tsx
+++ b/src/renderer/modules/components/RadioItem.tsx
@@ -34,7 +34,7 @@ export type RadioType = React.ComponentType<RadioProps> & {
 const radioStr = ".itemInfoClassName";
 
 export const Radio = (await waitForModule(filters.bySource(radioStr)).then((mod) =>
-  getFunctionBySource(radioStr, mod as ObjectExports),
+  getFunctionBySource(mod as ObjectExports, radioStr),
 )) as RadioType;
 
 interface RadioItemProps extends RadioProps {

--- a/src/renderer/modules/components/SelectItem.tsx
+++ b/src/renderer/modules/components/SelectItem.tsx
@@ -40,7 +40,7 @@ type SelectCompType = React.ComponentType<SelectCompProps>;
 const selectRgx = /.\.options,.=.\.placeholder/;
 
 const SelectComp = (await waitForModule(filters.bySource(selectRgx)).then((mod) =>
-  getFunctionBySource(selectRgx, mod as ObjectExports),
+  getFunctionBySource(mod as ObjectExports, selectRgx),
 )) as SelectCompType;
 
 export interface SelectProps extends SelectCompProps {

--- a/src/renderer/modules/components/SwitchItem.tsx
+++ b/src/renderer/modules/components/SwitchItem.tsx
@@ -25,10 +25,10 @@ const switchItemStr = ").dividerDefault";
 
 export const Switch = (await waitForModule(filters.bySource(switchModStr)).then((mod) => {
   if (typeof mod === "function") return mod;
-  return getFunctionBySource(switchRgx, mod as ObjectExports);
+  return getFunctionBySource(mod as ObjectExports, switchRgx);
 })) as SwitchType;
 
 export const SwitchItem = (await waitForModule(filters.bySource(switchItemStr)).then((mod) => {
   if (typeof mod === "function") return mod;
-  return getFunctionBySource(switchItemStr, mod as ObjectExports);
+  return getFunctionBySource(mod as ObjectExports, switchItemStr);
 })) as SwitchItemType;

--- a/src/renderer/modules/components/Text.tsx
+++ b/src/renderer/modules/components/Text.tsx
@@ -83,7 +83,7 @@ export type TextType = OriginalTextType &
   Record<"Normal" | "H1" | "H2" | "H3" | "H4" | "Eyebrow", OriginalTextType>;
 
 const mod = await waitForModule<ObjectExports>(filters.bySource("data-text-variant"));
-const OriginalText = getFunctionBySource("data-text-variant", mod) as OriginalTextType;
+const OriginalText = getFunctionBySource(mod, "data-text-variant") as OriginalTextType;
 
 function TextWithDefaultProps(defaultProps: CustomTextProps) {
   return (props: CustomTextProps) => {

--- a/src/renderer/modules/components/Tooltip.tsx
+++ b/src/renderer/modules/components/Tooltip.tsx
@@ -29,8 +29,8 @@ const rawTooltipMod = await waitForModule<Record<string, React.FC>>(
 );
 
 const TooltipMod = getFunctionBySource<React.FC>(
-  /shouldShowTooltip:!1/,
   rawTooltipMod,
+  /shouldShowTooltip:!1/,
 ) as OriginalTooltipType;
 
 const Tooltip: TooltipType = (props) => (

--- a/src/renderer/modules/webpack/common/contextMenu.ts
+++ b/src/renderer/modules/webpack/common/contextMenu.ts
@@ -19,7 +19,7 @@ export interface ContextMenu {
 const mod = await waitForModule(filters.bySource('type:"CONTEXT_MENU_OPEN"'));
 
 export default {
-  open: getFunctionBySource("stopPropagation", mod as ObjectExports),
-  openLazy: getFunctionBySource((f) => f.toString().length < 50, mod as ObjectExports),
-  close: getFunctionBySource("CONTEXT_MENU_CLOSE", mod as ObjectExports),
+  open: getFunctionBySource(mod as ObjectExports, "stopPropagation"),
+  openLazy: getFunctionBySource(mod as ObjectExports, (f) => f.toString().length < 50),
+  close: getFunctionBySource(mod as ObjectExports, "CONTEXT_MENU_CLOSE"),
 } as ContextMenu;

--- a/src/renderer/modules/webpack/common/modal.ts
+++ b/src/renderer/modules/webpack/common/modal.ts
@@ -92,10 +92,10 @@ const classes = getBySource<RawModule & ModalClasses>("().justifyStart")!;
 
 export default {
   openModal: getFunctionBySource<Modal["openModal"]>(
-    "onCloseRequest:null!=",
     mod as ObjectExports,
+    "onCloseRequest:null!=",
   )!,
-  closeModal: getFunctionBySource<Modal["closeModal"]>("onCloseCallback&&", mod as ObjectExports)!,
+  closeModal: getFunctionBySource<Modal["closeModal"]>(mod as ObjectExports, "onCloseCallback&&")!,
   Direction: classes?.Direction,
   Align: classes?.Align,
   Justify: classes?.Justify,

--- a/src/renderer/modules/webpack/common/toast.ts
+++ b/src/renderer/modules/webpack/common/toast.ts
@@ -26,10 +26,10 @@ export interface Toast {
 }
 
 const mod = await waitForModule(filters.bySource("queuedToasts"));
-const fn = getFunctionBySource("queuedToasts).concat", mod as ObjectExports)!;
+const fn = getFunctionBySource(mod as ObjectExports, "queuedToasts).concat")!;
 
 const propGenMod = await waitForModule(filters.bySource(/case \w+\.\w+\.FAILURE/));
-const propGenFn = getFunctionBySource("position", propGenMod as ObjectExports)!;
+const propGenFn = getFunctionBySource(propGenMod as ObjectExports, "position")!;
 
 const toast: ToastFn = (content, kind = Kind.SUCCESS, opts = undefined) => {
   const props = propGenFn(content, kind, opts);

--- a/src/renderer/modules/webpack/index.ts
+++ b/src/renderer/modules/webpack/index.ts
@@ -624,6 +624,20 @@ export function getByValue(
 
 // Specialized, inner-module searchers
 
+// TODO: Remove support for this
+/**
+ * @deprecated The argument order has been changed. Please put the module first and the matcher second.
+ */
+export function getFunctionBySource<T extends AnyFunction = AnyFunction>(
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  module: string | RegExp | ((func: Function) => boolean),
+  match: ObjectExports,
+): T | undefined;
+export function getFunctionBySource<T extends AnyFunction = AnyFunction>(
+  module: ObjectExports,
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  match: string | RegExp | ((func: Function) => boolean),
+): T | undefined;
 /**
  * Search for a function within a module by its source code.
  *
@@ -632,19 +646,46 @@ export function getByValue(
  */
 export function getFunctionBySource<T extends AnyFunction = AnyFunction>(
   // eslint-disable-next-line @typescript-eslint/ban-types
-  match: string | RegExp | ((func: Function) => boolean),
-  module: ObjectExports,
+  module: ObjectExports | string | RegExp | ((func: Function) => boolean),
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  match: ObjectExports | string | RegExp | ((func: Function) => boolean),
 ): T | undefined {
-  return Object.values(module).find((v) => {
+  const isDeprecatedOrder =
+    typeof module === "string" || module instanceof RegExp || typeof module === "function";
+  const realModule = (isDeprecatedOrder ? match : module) as ObjectExports;
+  const realMatch = (isDeprecatedOrder ? module : match) as
+    | string
+    | RegExp
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    | ((func: Function) => boolean);
+
+  return Object.values(realModule).find((v) => {
     if (typeof v !== "function") return false;
 
-    if (typeof match === "function") {
-      return match(v);
+    if (typeof realMatch === "function") {
+      return realMatch(v);
     } else {
-      return typeof match === "string" ? v.toString().includes(match) : match.test(v.toString());
+      return typeof realMatch === "string"
+        ? v.toString().includes(realMatch)
+        : realMatch.test(v.toString());
     }
   }) as T | undefined;
 }
+
+// TODO: Remove support for this
+/**
+ * @deprecated The argument order has been changed. Please put the module first and the matcher second.
+ */
+export function getFunctionKeyBySource<P extends keyof T, T extends ObjectExports = ObjectExports>(
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  module: string | RegExp | ((func: Function) => boolean),
+  match: T,
+): P | undefined;
+export function getFunctionKeyBySource<P extends keyof T, T extends ObjectExports = ObjectExports>(
+  module: T,
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  match: string | RegExp | ((func: Function) => boolean),
+): P | undefined;
 
 /**
  * Search for a function within a module by its source code. Returns the key of the function.
@@ -656,14 +697,29 @@ export function getFunctionBySource<T extends AnyFunction = AnyFunction>(
  * Useful for getting the prop name to inject into.
  */
 export function getFunctionKeyBySource<P extends keyof T, T extends ObjectExports = ObjectExports>(
-  match: string | RegExp,
-  module: T,
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  module: T | string | RegExp | ((func: Function) => boolean),
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  match: T | string | RegExp | ((func: Function) => boolean),
 ): P | undefined {
-  return Object.entries(module).find(([_, v]) => {
-    if (typeof v !== "function") {
-      return false;
-    }
+  const isDeprecatedOrder =
+    typeof module === "string" || module instanceof RegExp || typeof module === "function";
+  const realModule = (isDeprecatedOrder ? match : module) as T;
+  const realMatch = (isDeprecatedOrder ? module : match) as
+    | string
+    | RegExp
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    | ((func: Function) => boolean);
 
-    return typeof match === "string" ? v.toString().includes(match) : match.test(v.toString());
+  return Object.entries(realModule).find(([_, v]) => {
+    if (typeof v !== "function") return false;
+
+    if (typeof realMatch === "function") {
+      return realMatch(v);
+    } else {
+      return typeof realMatch === "string"
+        ? v.toString().includes(realMatch)
+        : realMatch.test(v.toString());
+    }
   })?.[0] as P | undefined;
 }

--- a/src/renderer/util.ts
+++ b/src/renderer/util.ts
@@ -134,7 +134,7 @@ export async function goToOrJoinServer(invite: string): Promise<void> {
       throw new Error("Could not find transitionTo");
     }
 
-    transitionTo = getFunctionBySource("Transitioning to", transitionToMod as ObjectExports);
+    transitionTo = getFunctionBySource(transitionToMod as ObjectExports, "Transitioning to");
     if (!transitionTo) {
       throw new Error("Could not find transitionTo");
     }


### PR DESCRIPTION
This switches the argument order for those functions, so the module goes first and the query goes second. This is consistent with `getExportsForProps` and just makes more sense chronologically. 

This would be a breaking change, but I wanted to avoid that because many plugins use this. I decided to temporarily keep support for the previous order and add code to handle both orders. The overload for that layout is marked as deprecated, so JSDoc will warn you. We'll leave it for a few weeks and then remove the deprecated layout, at which point developers should've had plenty of time to update their plugins.