### PR TITLE
Rename Replugged's asar to replugged.asar

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -30,7 +30,7 @@ const preBundle: esbuild.Plugin = {
           name: "replugged",
         }),
       );
-      asar.createPackage("dist", "app.asar");
+      asar.createPackage("dist", "replugged.asar");
     });
   },
 };

--- a/scripts/inject/injector.ts
+++ b/scripts/inject/injector.ts
@@ -89,7 +89,7 @@ export const inject = async (
     return false;
   }
 
-  const fileToCheck = join(__dirname, "..", "..", prod ? "app.asar" : "dist/main.js");
+  const fileToCheck = join(__dirname, "..", "..", prod ? "replugged.asar" : "dist/main.js");
   const fileToCheckExists = await stat(fileToCheck)
     .then(() => true)
     .catch(() => false);
@@ -173,11 +173,11 @@ export const inject = async (
   }
 
   const entryPoint = prod
-    ? join(CONFIG_PATH, "app.asar")
+    ? join(CONFIG_PATH, "replugged.asar")
     : join(__dirname, "..", "..", "dist/main.js");
 
   if (prod) {
-    await copyFile(join(__dirname, "..", "..", "app.asar"), entryPoint);
+    await copyFile(join(__dirname, "..", "..", "replugged.asar"), entryPoint);
   }
 
   await mkdir(appDir);


### PR DESCRIPTION
For clarity, so that there is no confusion between Discord's app.asar and 
the asar containing Replugged's code.
