### PR TITLE
Fix home path for sudo

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,7 @@
     "https://json.schemastore.org/github-workflow.json": ".github/workflows/cspell.yml"
   },
   "prettier.prettierPath": "./node_modules/prettier",
+  "prettier.configPath": "./.prettierrc.json",
   "typescript.enablePromptUseWorkspaceTsdk": true,
   "typescript.tsdk": "./node_modules/typescript/lib",
   "eslint.format.enable": true

--- a/scripts/inject/checks/elevate.ts
+++ b/scripts/inject/checks/elevate.ts
@@ -6,8 +6,6 @@ const tryToElevate = (command: string): void => {
     ...command.split(" "),
     path.join(__dirname, "..", "..", "..", "node_modules", ".bin", "tsx"),
     ...process.argv.slice(1),
-    `--home="${process.env.HOME}"`,
-    `--xdg-data-home="${process.env.XDG_DATA_HOME}"`,
   ];
   const { error } = spawnSync("env", args, { stdio: "inherit" });
   if (!error) {

--- a/scripts/inject/index.ts
+++ b/scripts/inject/index.ts
@@ -20,21 +20,6 @@ const platformModules = {
 
 const exitCode = process.argv.includes("--no-exit-codes") ? 0 : 1;
 const prod = process.argv.includes("--production");
-const homeArg = process.argv
-  .find((v) => v.startsWith("--home="))
-  ?.replace(/^--home=/, "")
-  ?.replace(/^"(.*)"$/, "$1");
-const xdgDataHomeArg = process.argv
-  .find((v) => v.startsWith("--xdg-data-home="))
-  ?.replace(/^--xdg-data-home=/, "")
-  ?.replace(/^"(.*)"$/, "$1");
-if (homeArg) {
-  process.env.HOME = homeArg;
-  delete process.env.XDG_DATA_HOME;
-}
-if (xdgDataHomeArg) {
-  process.env.XDG_DATA_HOME = xdgDataHomeArg;
-}
 const processArgs = process.argv.filter((v) => !v.startsWith("-"));
 
 if (!(process.platform in platformModules)) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -14,10 +14,18 @@ export const configPathFn = (): string => {
       if (process.env.XDG_CONFIG_HOME) {
         return join(process.env.XDG_CONFIG_HOME, REPLUGGED_FOLDER_NAME);
       }
-      if (realUser) {
-        // Get the home directory of the sudo user from /etc/passwd
-        const homeDir = execSync(`getent passwd ${realUser}`).toString('utf-8').split(':')[5];
-        return join(homeDir, ".config", REPLUGGED_FOLDER_NAME);
+      try {
+        if (realUser) {
+          // Get the home directory of the sudo user from /etc/passwd
+          const homeDir = execSync(`getent passwd ${realUser}`, {
+            stdio: [null, null, "ignore"],
+          })
+            .toString("utf-8")
+            .split(":")[5];
+          return join(homeDir, ".config", REPLUGGED_FOLDER_NAME);
+        }
+      } catch {
+        console.error("Could not get home directory of sudo/doas user. Falling back to $HOME.");
       }
       return join(process.env.HOME || "", ".config", REPLUGGED_FOLDER_NAME);
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -5,36 +5,46 @@ import { join } from "path";
 const REPLUGGED_FOLDER_NAME = "replugged";
 export const configPathFn = (): string => {
   const realUser = process.env.SUDO_USER || process.env.DOAS_USER;
+  let home = process.env.HOME;
   switch (process.platform) {
     case "win32":
       return join(process.env.APPDATA || "", REPLUGGED_FOLDER_NAME);
     case "darwin":
-      return join(process.env.HOME || "", "Library", "Application Support", REPLUGGED_FOLDER_NAME);
+      return join(home || "", "Library", "Application Support", REPLUGGED_FOLDER_NAME);
     default:
       if (process.env.XDG_CONFIG_HOME) {
         return join(process.env.XDG_CONFIG_HOME, REPLUGGED_FOLDER_NAME);
       }
-      try {
-        if (realUser) {
+
+      if (realUser) {
+        try {
           // Get the home directory of the sudo user from /etc/passwd
-          const homeDir = execSync(`getent passwd ${realUser}`, {
+          const realUserHome = execSync(`getent passwd ${realUser}`, {
             stdio: [null, null, "ignore"],
           })
             .toString("utf-8")
             .split(":")[5];
-          return join(homeDir, ".config", REPLUGGED_FOLDER_NAME);
+          if (realUserHome && existsSync(realUserHome)) {
+            home = realUserHome;
+          } else {
+            console.error(
+              new Error(`Passwd entry for "${realUser}" contains an invalid home directory.`),
+            );
+            process.exit(1);
+          }
+        } catch (error) {
+          console.error("Could not find passwd entry of sudo/doas user", error);
+          process.exit(1);
         }
-      } catch {
-        console.error("Could not get home directory of sudo/doas user. Falling back to $HOME.");
       }
-      return join(process.env.HOME || "", ".config", REPLUGGED_FOLDER_NAME);
+      return join(home || "", ".config", REPLUGGED_FOLDER_NAME);
   }
 };
 
 export const CONFIG_PATH = configPathFn();
 
 if (!existsSync(CONFIG_PATH)) {
-  mkdirSync(CONFIG_PATH);
+  mkdirSync(CONFIG_PATH, { recursive: true });
 }
 
 const CONFIG_FOLDER_NAMES = ["plugins", "themes", "settings", "quickcss"] as const;

--- a/src/util.ts
+++ b/src/util.ts
@@ -11,8 +11,11 @@ export const configPathFn = (): string => {
     default:
       if (process.env.XDG_CONFIG_HOME) {
         return join(process.env.XDG_CONFIG_HOME, REPLUGGED_FOLDER_NAME);
+      } else {
+        const realUser = process.env.SUDO_USER || process.env.DOAS_USER;
+        const home = realUser ? join("/home", realUser) : process.env.HOME;
+        return join(home || "", ".config", REPLUGGED_FOLDER_NAME);
       }
-      return join(process.env.HOME || "", ".config", REPLUGGED_FOLDER_NAME);
   }
 };
 


### PR DESCRIPTION
This fixes the injector failing as sudo due to this part of src/util.ts
```ts
if (!existsSync(CONFIG_PATH)) {
  mkdirSync(CONFIG_PATH);
}
```
Which is ran before the the inject script can overwrite `process.env.HOME`, so it tries to create a folder in `/root/.config` which might not exist and is the wrong folder anyways

The fix checks for `SUDO_USER` or `DOAS_USER` which are always set by the sudo/doas util, and finds the home directory from `/etc/passwd` (or whetever ur passwd file is)