### PR TITLE
feat: add more channel methods

### DIFF
--- a/src/renderer/modules/common/channels.ts
+++ b/src/renderer/modules/common/channels.ts
@@ -19,10 +19,21 @@ export interface Channels extends Store {
 
   // ChannelStore
   getAllThreadsForParent(channelId: string): Channel[];
+  getBasicChannel(channelId: string): Channel[];
+  getCachedChannelJsonForGuild(e: unknown): unknown;
   getChannel(channelId: string): Channel;
   getDMFromUserId(userId: string): Channel;
   getDMUserIds(): string[];
+  getGuildChannelsVersion(guildId: string): number;
+  getInitialOverlayState(): Record<number, Channel>;
+  getMutableBasicGuildChannelsForGuild(guildId: string): Record<number, Channel>;
+  getMutableGuildChannelsForGuild(guildId: string): Record<number, Channel>;
+  getMutablePrivateChannels(): Record<number, Channel>;
+  getPrivateChannelsVersion(): number;
+  getSortedPrivateChannels(): Channel[]
   hasChannel(channelId: string): boolean;
+  hasRestoredGuild(): boolean;
+  loadAllGuildAndPrivateChannelsFromDisk(): Channel[];
 }
 
 export default {

--- a/src/renderer/modules/common/channels.ts
+++ b/src/renderer/modules/common/channels.ts
@@ -1,5 +1,6 @@
-import { filters, getExportsForProps, waitForModule } from "../webpack";
+import { filters, getExportsForProps, waitForProps } from "../webpack";
 import type { Store } from "./flux";
+import { Channel } from "discord-types/general";
 
 export interface LastChannelFollowingDestination {
   channelId: string;
@@ -7,6 +8,7 @@ export interface LastChannelFollowingDestination {
 }
 
 export interface Channels extends Store {
+  // Selected Channel Store
   getChannelId: (guildId?: string) => string | undefined;
   getCurrentlySelectedChannelId: (guildId?: string) => string | undefined;
   getLastChannelFollowingDestination: () => LastChannelFollowingDestination;
@@ -14,12 +16,16 @@ export interface Channels extends Store {
   getLastSelectedChannels: (guildId?: string) => string | undefined;
   getMostRecentSelectedTextChannelId: (guildId?: string) => string | undefined;
   getVoiceChannelId: () => string | undefined;
+
+  // ChannelStore
+  getAllThreadsForParent(channelId: string): Channel[];
+  getChannel(channelId: string): Channel;
+  getDMFromUserId(userId: string): Channel;
+  getDMUserIds(): string[];
+  hasChannel(channelId: string): boolean;
 }
 
-export default (await waitForModule(
-  filters.byProps("getChannelId", "getLastSelectedChannelId", "getVoiceChannelId"),
-).then((mod) =>
-  Object.getPrototypeOf(
-    getExportsForProps(mod, ["getChannelId", "getLastSelectedChannelId", "getVoiceChannelId"]),
-  ),
-)) as Channels;
+export default {
+  ...(await waitForProps("getChannelId", "getLastSelectedChannelId", "getVoiceChannelId").then(Object.getPrototypeOf)),
+  ...(await waitForProps("getChannel", "hasChannel").then(Object.getPrototypeOf))
+} as Channels;

--- a/src/renderer/modules/common/channels.ts
+++ b/src/renderer/modules/common/channels.ts
@@ -1,4 +1,4 @@
-import { filters, getExportsForProps, waitForProps } from "../webpack";
+import { waitForProps } from "../webpack";
 import type { Store } from "./flux";
 import { Channel } from "discord-types/general";
 
@@ -26,6 +26,8 @@ export interface Channels extends Store {
 }
 
 export default {
-  ...(await waitForProps("getChannelId", "getLastSelectedChannelId", "getVoiceChannelId").then(Object.getPrototypeOf)),
-  ...(await waitForProps("getChannel", "hasChannel").then(Object.getPrototypeOf))
+  ...(await waitForProps("getChannelId", "getLastSelectedChannelId", "getVoiceChannelId").then(
+    Object.getPrototypeOf,
+  )),
+  ...(await waitForProps("getChannel", "hasChannel").then(Object.getPrototypeOf)),
 } as Channels;

--- a/src/renderer/modules/common/channels.ts
+++ b/src/renderer/modules/common/channels.ts
@@ -30,7 +30,7 @@ export interface Channels extends Store {
   getMutableGuildChannelsForGuild(guildId: string): Record<number, Channel>;
   getMutablePrivateChannels(): Record<number, Channel>;
   getPrivateChannelsVersion(): number;
-  getSortedPrivateChannels(): Channel[]
+  getSortedPrivateChannels(): Channel[];
   hasChannel(channelId: string): boolean;
   hasRestoredGuild(): boolean;
   loadAllGuildAndPrivateChannelsFromDisk(): Channel[];


### PR DESCRIPTION
This pr adds several new functions to the Channel common module. New functions typehinted are `getAllThreadsForParent`, `getChannel`, `getDMFromUserId`, `GetDMUserIds`, and `hasChannel`, but the attached image has all of the functions from the store.

![image](https://user-images.githubusercontent.com/84055084/222872787-e34665b0-6244-488c-a0fa-6d7a9e230a5f.png)

Closes #344 