### PR TITLE
fix(installer): Set ownership of Replugged config to user

### DIFF
--- a/scripts/inject/injector.ts
+++ b/scripts/inject/injector.ts
@@ -178,8 +178,15 @@ export const inject = async (
 
   if (prod) {
     await copyFile(join(__dirname, "..", "..", "replugged.asar"), entryPoint);
-    const { uid, gid } = await stat(CONFIG_PATH);
-    await chown(entryPoint, uid, gid);
+    if (["linux", "darwin"].includes(process.platform)) {
+      try {
+        // Adjust ownership of config folder and asar file to match the parent config folder
+        // We want to make sure all Replugged files are owned by the user
+        const { uid, gid } = await stat(join(CONFIG_PATH, ".."));
+        await chown(CONFIG_PATH, uid, gid);
+        await chown(entryPoint, uid, gid);
+      } catch {}
+    }
   }
 
   await mkdir(appDir);

--- a/scripts/inject/injector.ts
+++ b/scripts/inject/injector.ts
@@ -1,4 +1,4 @@
-import { copyFile, mkdir, rename, rm, stat, writeFile } from "fs/promises";
+import { chown, copyFile, mkdir, rename, rm, stat, writeFile } from "fs/promises";
 import { join, sep } from "path";
 import { AnsiEscapes } from "./util";
 import readline from "readline";
@@ -178,6 +178,8 @@ export const inject = async (
 
   if (prod) {
     await copyFile(join(__dirname, "..", "..", "replugged.asar"), entryPoint);
+    const { uid, gid } = await stat(CONFIG_PATH);
+    await chown(entryPoint, uid, gid);
   }
 
   await mkdir(appDir);


### PR DESCRIPTION
We want to make sure that the Replugged files are not owned by root, otherwise the files may not be manageable by Discord.