### PR TITLE
added /usr/lib as a known path

### DIFF
--- a/scripts/inject/platforms/linux.ts
+++ b/scripts/inject/platforms/linux.ts
@@ -23,6 +23,7 @@ const findAppDir = async (platform: DiscordPlatform): Promise<string> => {
   const KnownLinuxPaths = {
     stable: [
       "/usr/share/discord",
+      "/usr/lib/discord",
       "/usr/lib64/discord",
       "/opt/discord",
       "/opt/Discord",
@@ -32,6 +33,7 @@ const findAppDir = async (platform: DiscordPlatform): Promise<string> => {
     ],
     ptb: [
       "/usr/share/discord-ptb",
+      "/usr/lib/discord-ptb",
       "/usr/lib64/discord-ptb",
       "/opt/discord-ptb",
       "/opt/DiscordPTB",
@@ -39,6 +41,7 @@ const findAppDir = async (platform: DiscordPlatform): Promise<string> => {
     ],
     canary: [
       "/usr/share/discord-canary",
+      "/usr/lib/discord-canary",
       "/usr/lib64/discord-canary",
       "/opt/discord-canary",
       "/opt/DiscordCanary",
@@ -48,6 +51,7 @@ const findAppDir = async (platform: DiscordPlatform): Promise<string> => {
     ],
     dev: [
       "/usr/share/discord-development",
+      "/usr/lib/discord-development",
       "/usr/lib64/discord-development",
       "/opt/discord-development",
       "/opt/DiscordDevelopment",


### PR DESCRIPTION
there should also be a check if the generated path even exists.  
sometimes there's no resources folder so the asar file is just sitting on the root of the known path:  
  
before injection: 
![image](https://user-images.githubusercontent.com/39243708/225174141-bcce4c98-5e95-4973-8747-0a7aa0139300.png)
after injection:
![image](https://user-images.githubusercontent.com/39243708/225174221-e3579a9f-c3f9-450e-8cfc-4577addcf501.png)
