### PR TITLE
Adds shebang to replugged executable

### DIFF
--- a/bin/replugged.mjs
+++ b/bin/replugged.mjs
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 const directory = process.cwd();
 import asar from "@electron/asar";
 import { Parcel } from "@parcel/core";


### PR DESCRIPTION
The executable failed to run on Linux when I tried to run a command to build plugin.
![image](https://user-images.githubusercontent.com/52526068/225896381-7caa693e-96fe-49c7-9ee8-519049e1303f.png)

Adding a shebang line fixed the problem. Now I can run the command with no error.
![image](https://user-images.githubusercontent.com/52526068/225897268-1d84785c-5346-4394-ba5e-eb2d55c8e78f.png)
