### PR TITLE
fix: Switch component

### DIFF
--- a/src/renderer/modules/common/guilds.ts
+++ b/src/renderer/modules/common/guilds.ts
@@ -18,7 +18,6 @@ export type Guilds = (Store & Record<string, unknown>) & {
   getLastSelectedGuildId: () => string | undefined;
   getLastSelectedTimestamp: (guildId: string) => number;
   getState: () => State;
-  getTabsV2SelectedGuildId: () => string | undefined;
   isLoaded: () => boolean;
 };
 

--- a/src/renderer/modules/components/CheckboxItem.tsx
+++ b/src/renderer/modules/components/CheckboxItem.tsx
@@ -21,7 +21,7 @@ interface CheckboxProps {
   onChange?: (e: React.ChangeEvent<HTMLInputElement>, state: boolean) => void;
 }
 
-export type CheckboxType = React.ComponentType<CheckboxProps> & {
+export type CheckboxType = React.FC<React.PropsWithChildren<CheckboxProps>> & {
   defaultProps: CheckboxProps;
   Types: Record<"DEFAULT" | "INVERTED" | "GHOST" | "ROW", string>;
   Aligns: Record<"TOP" | "CENTER", string>;

--- a/src/renderer/modules/components/SwitchItem.tsx
+++ b/src/renderer/modules/components/SwitchItem.tsx
@@ -21,12 +21,11 @@ export type SwitchItemType = ReactComponent<{
 }>;
 
 const switchModStr = "xMinYMid meet";
-const switchRgx = /{className:\w+\(\)\(\w+,\w+\.className\)}/;
 const switchItemStr = ").dividerDefault";
 
 export const Switch = (await waitForModule(filters.bySource(switchModStr)).then((mod) => {
   if (typeof mod === "function") return mod;
-  return getFunctionBySource(mod as ObjectExports, switchRgx);
+  return getFunctionBySource(mod as ObjectExports, switchModStr);
 })) as SwitchType;
 
 export const SwitchItem = (await waitForModule(filters.bySource(switchItemStr)).then((mod) => {


### PR DESCRIPTION
Fixes the `Switch` component being undefined.
Includes a type fix for the `Checkbox` component not accepting children and removes a function from the `guilds` common module.