### PR TITLE
fix: language coremod plaintext patch

### DIFF
--- a/src/renderer/coremods/language/plaintextPatches.ts
+++ b/src/renderer/coremods/language/plaintextPatches.ts
@@ -7,11 +7,11 @@ export default [
     find: "getAvailableLocales",
     replacements: [
       {
-        match: /(\.Messages\.LANGUAGE,)\s*children:((?:[^}]*}){3}[^}]*)/,
+        match: /(\.Messages\.LANGUAGE,)\s*children:((?:[^}]*?}){3}\))/,
         replace: (_, prefix, ogChild) => `${prefix}children:[${coremodStr}.Card(),${ogChild}]`,
       },
       {
-        match: /children:\[(.+\.localeName[^\]]*)]/,
+        match: /children:\[(.+?\.localeName[^\]]*?)]/,
         replace: (_, ogChild) => `children:[${coremodStr}.Percentage(${ogChild})]`,
       },
     ],

--- a/src/renderer/coremods/language/plaintextPatches.ts
+++ b/src/renderer/coremods/language/plaintextPatches.ts
@@ -1,18 +1,18 @@
 import type { PlaintextPatch } from "src/types";
 
+const coremodStr = "replugged.coremods.coremods.language";
+
 export default [
   {
     find: "getAvailableLocales",
     replacements: [
       {
-        match: /\.Messages\.LANGUAGE,children:((?:[^}]*}){3}[^}]*)/,
-        replace: (_, ogChild) =>
-          `.Messages.LANGUAGE,children:[replugged.coremods.coremods.language.Card(),${ogChild}]`,
+        match: /(\.Messages\.LANGUAGE,)\s*children:((?:[^}]*}){3}[^}]*)/,
+        replace: (_, prefix, ogChild) => `${prefix}children:[${coremodStr}.Card(),${ogChild}]`,
       },
       {
         match: /children:\[(.+\.localeName[^\]]*)]/,
-        replace: (_, ogChild) =>
-          `children:[replugged.coremods.coremods.language.Percentage(${ogChild})]`,
+        replace: (_, ogChild) => `children:[${coremodStr}.Percentage(${ogChild})]`,
       },
     ],
   },


### PR DESCRIPTION
Notice stopped appearing due to a whitespace. With this fix all possible whitespace should be matched.