### PR TITLE
Load Quick CSS after themes

### DIFF
--- a/src/renderer/managers/ignition.ts
+++ b/src/renderer/managers/ignition.ts
@@ -16,12 +16,13 @@ export async function start(): Promise<void> {
 
   loadStyleSheet("replugged://renderer.css");
   i18n.load();
-  quickCSS.load();
   await Promise.all([
     coremods.startAll(),
     plugins.startAll(),
     themes.loadMissing().then(themes.loadAll),
   ]);
+  // Quick CSS needs to be called after themes are loaded so that it will override the theme's CSS
+  quickCSS.load();
 
   log(
     "Ignition",


### PR DESCRIPTION
This addresses an issue some users were having where Quick CSS wasn't applying properly on load. This was due to it being called before themes are loaded, which means the themes override the Quick CSS. By loading Quick CSS after, it should fix the issue.