### PR TITLE
Get addons RPC command

### DIFF
--- a/src/renderer/coremods/installer/index.tsx
+++ b/src/renderer/coremods/installer/index.tsx
@@ -3,6 +3,8 @@ import { filters, getFunctionKeyBySource, waitForModule } from "src/renderer/mod
 import { ObjectExports } from "src/types";
 import { registerRPCCommand } from "../rpc";
 import { InstallResponse, InstallerSource, installFlow, isValidSource } from "./util";
+import { plugins } from "src/renderer/managers/plugins";
+import { themes } from "src/renderer/managers/themes";
 
 const injector = new Injector();
 const logger = Logger.coremod("Installer");
@@ -52,7 +54,7 @@ if (window.RepluggedNative.getVersion() === "dev") {
 }
 
 function injectRpc(): void {
-  const uninjectRpc = registerRPCCommand("REPLUGGED_INSTALL", {
+  const uninjectInstall = registerRPCCommand("REPLUGGED_INSTALL", {
     scope: {
       $any: scopes,
     },
@@ -76,7 +78,21 @@ function injectRpc(): void {
     },
   });
 
-  uninjectFns.push(uninjectRpc);
+  const uninjectList = registerRPCCommand("REPLUGGED_LIST_ADDONS", {
+    scope: {
+      $any: scopes,
+    },
+    handler: () => {
+      const pluginIds = [...plugins.keys()];
+      const themeIds = [...themes.keys()];
+      return {
+        plugins: pluginIds,
+        themes: themeIds,
+      };
+    },
+  });
+
+  uninjectFns.push(uninjectInstall, uninjectList);
 }
 
 async function injectLinks(): Promise<void> {


### PR DESCRIPTION
Adds an RPC command to get a list of addon IDs which will be used in the store. Like the install command, it's restricted to replugged.dev only, unless you're in dev mode in which case it'll also allow requests from localhost.