### PR TITLE
Updates to addon pages

### DIFF
--- a/src/renderer/coremods/badges/badge.tsx
+++ b/src/renderer/coremods/badges/badge.tsx
@@ -1,9 +1,8 @@
 import { Messages } from "@common/i18n";
 import React from "@common/react";
 import { Clickable, Tooltip } from "@components";
-import { RawModule } from "src/types";
-import { filters, getByProps, waitForModule } from "../../modules/webpack";
-import { goToOrJoinServer } from "../../util";
+import { getByProps } from "../../modules/webpack";
+import { goToOrJoinServer, openExternal } from "../../util";
 import { generalSettings } from "../settings/pages";
 import "./badge.css";
 import Badges from "./badges";
@@ -103,12 +102,6 @@ export type BadgeComponent = (args: BadgeArgs) => React.ReactElement<{
   children: React.ReactElement[];
   className: string;
 }>;
-
-// todo: move to common modules
-const openExternal = (url: string): Promise<void> =>
-  waitForModule<RawModule & ((url: string) => Promise<void>)>(
-    filters.bySource('.target="_blank";'),
-  ).then((module) => module(url));
 
 // todo: make global (configurable?) variables for these
 const openContributorsPage = (): Promise<void> =>

--- a/src/renderer/coremods/installer/util.tsx
+++ b/src/renderer/coremods/installer/util.tsx
@@ -1,11 +1,12 @@
 import { modal, toast } from "@common";
 import { Messages } from "@common/i18n";
-import { Button } from "@components";
+import { Button, Notice } from "@components";
 import { Logger } from "@replugged";
 import { setUpdaterState } from "src/renderer/managers/updater";
 import type { AnyAddonManifest, CheckResultSuccess } from "src/types";
 import * as pluginManager from "../../managers/plugins";
 import * as themeManager from "../../managers/themes";
+import { getAddonType, label } from "../settings/pages";
 
 const logger = Logger.coremod("Installer");
 
@@ -176,14 +177,27 @@ async function showInstallPrompt(manifest: AnyAddonManifest): Promise<boolean> {
   const authors = authorList([manifest.author].flat().map((a) => a.name));
 
   const title = Messages.REPLUGGED_INSTALL_MODAL_HEADER.format({ type });
-  const body = Messages.REPLUGGED_INSTALLER_INSTALL_PROMPT_BODY.format({
+  const text = Messages.REPLUGGED_INSTALLER_INSTALL_PROMPT_BODY.format({
     name: manifest.name,
     authors,
   });
 
   const res = await modal.confirm({
     title,
-    body,
+    body: (
+      <>
+        {text}
+        {manifest.updater?.type !== "store" ? (
+          <div style={{ marginTop: "16px" }}>
+            <Notice messageType={Notice.Types.ERROR}>
+              {Messages.REPLUGGED_ADDON_NOT_REVIEWED_DESC.format({
+                type: label(getAddonType(manifest.type)),
+              })}
+            </Notice>
+          </div>
+        ) : null}
+      </>
+    ),
     confirmText: Messages.REPLUGGED_CONFIRM,
     cancelText: Messages.REPLUGGED_CANCEL,
   });

--- a/src/renderer/coremods/settings/pages/Updater.tsx
+++ b/src/renderer/coremods/settings/pages/Updater.tsx
@@ -15,6 +15,7 @@ import {
 } from "src/renderer/managers/updater";
 import { sleep, useSetting, useSettingArray } from "src/renderer/util";
 import Icons from "../icons";
+import { getAddonType, label } from "./Addons";
 import "./Updater.css";
 
 const logger = Logger.coremod("Settings:Updater");
@@ -208,11 +209,8 @@ export const Updater = (): React.ReactElement => {
           const { manifest } = addon;
           const sourceLink = update.webUrl;
           return (
-            <>
-              <Flex
-                className="replugged-updater-item"
-                justify={Flex.Justify.BETWEEN}
-                align={Flex.Align.CENTER}>
+            <div className="replugged-updater-item">
+              <Flex justify={Flex.Justify.BETWEEN} align={Flex.Align.CENTER}>
                 <div>
                   <Flex align={Flex.Align.CENTER} style={{ gap: "5px", marginBottom: "5px" }}>
                     <Text variant="heading-sm/normal" tag="h2" color="header-secondary">
@@ -250,7 +248,16 @@ export const Updater = (): React.ReactElement => {
                   </Button>
                 )}
               </Flex>
-            </>
+              {manifest.type !== "replugged" && manifest.updater?.type !== "store" ? (
+                <div style={{ marginTop: "8px" }}>
+                  <Notice messageType={Notice.Types.ERROR}>
+                    {Messages.REPLUGGED_ADDON_NOT_REVIEWED_DESC.format({
+                      type: label(getAddonType(manifest.type)),
+                    })}
+                  </Notice>
+                </div>
+              ) : null}
+            </div>
           );
         })}
       </Flex>

--- a/src/renderer/util.ts
+++ b/src/renderer/util.ts
@@ -170,6 +170,14 @@ export async function goToOrJoinServer(invite: string): Promise<void> {
   });
 }
 
+export async function openExternal(url: string): Promise<void> {
+  const mod = getBySource<(url: string) => Promise<void>>('.target="_blank"');
+  if (!mod) {
+    throw new Error("Could not find openExternal");
+  }
+  return await mod(url);
+}
+
 type ValType<T> =
   | T
   | React.ChangeEvent<HTMLInputElement>


### PR DESCRIPTION
- Set link or store addons to go to their page on the store (`https://replugged.dev/store/:id`, uses the backend URL defined in settings)
- Add a button to the top of addon settings to open the store addon list (`https://replugged.dev/store/:type`, uses the backend URL defined in settings)
- Add warning for non-store addons. This is shown in the install modal, the card for the addon in settings, and the updater card in addon settings. (Closes #466)
- Moves `openExternal` to util