### PR TITLE
Ignition fix

### DIFF
--- a/src/renderer/coremods/notices/plaintextPatches.tsx
+++ b/src/renderer/coremods/notices/plaintextPatches.tsx
@@ -9,7 +9,7 @@ export default [
       {
         match: /(\(\)\.base,children:\[)(.+?}\)),/,
         replace: (_, prefix, noticeWrapper) =>
-          `${prefix}${coremodStr}.AnnouncementContainer({originalRes:${noticeWrapper}}),`,
+          `${prefix}${coremodStr}?.AnnouncementContainer({originalRes:${noticeWrapper}}) ?? ${noticeWrapper},`,
       },
     ],
   },

--- a/src/renderer/managers/ignition.ts
+++ b/src/renderer/managers/ignition.ts
@@ -8,7 +8,7 @@ import * as coremods from "./coremods";
 import * as plugins from "./plugins";
 import * as themes from "./themes";
 import * as quickCSS from "./quick-css";
-import { loadStyleSheet } from "../util";
+import { loadStyleSheet, waitFor } from "../util";
 import { startAutoUpdateChecking } from "./updater";
 
 export async function start(): Promise<void> {
@@ -71,7 +71,10 @@ export async function ignite(): Promise<void> {
   await plugins.runPlaintextPatches();
   await waitForReady;
   signalStart();
-  await commonReady;
-  await componentsReady;
+  // if you uncomment the waitFor function underneath, it will make it so common/components/coremods/plugins gets loaded after most of the elements in window are loaded
+  // you will need to make the plain text patches have fail safe for before plugin/coremods gets loaded
+  //await waitFor("[class^=wrapper-]");
+  await commonReady();
+  await componentsReady();
   await start();
 }

--- a/src/renderer/modules/common/index.ts
+++ b/src/renderer/modules/common/index.ts
@@ -1,20 +1,21 @@
 import { error } from "../logger";
 
-const modulePromises: Array<Promise<void>> = [];
+const modulePromises: Array<() => Promise<void>> = [];
 
 function importTimeout<T>(name: string, moduleImport: Promise<T>, cb: (mod: T) => void): void {
   modulePromises.push(
-    new Promise<void>((res, rej) => {
-      const timeout = setTimeout(() => {
-        error("CommonModules", name, void 0, `Could not find module "${name}"`);
-        rej(new Error(`Module not found: "${name}`));
-      }, 5_000);
-      void moduleImport.then((mod) => {
-        clearTimeout(timeout);
-        cb(mod);
-        res();
-      });
-    }),
+    () =>
+      new Promise<void>((res, rej) => {
+        const timeout = setTimeout(() => {
+          error("CommonModules", name, void 0, `Could not find module "${name}"`);
+          rej(new Error(`Module not found: "${name}`));
+        }, 1_000);
+        void moduleImport.then((mod) => {
+          clearTimeout(timeout);
+          cb(mod);
+          res();
+        });
+      }),
   );
 }
 
@@ -122,6 +123,7 @@ importTimeout("parser", import("./parser"), (mod) => (parser = mod.default));
  * @internal
  * @hidden
  */
-export const ready = new Promise<void>((resolve) =>
-  Promise.allSettled(modulePromises).then(() => resolve()),
-);
+export const ready = (): Promise<void> =>
+  new Promise<void>((resolve) =>
+    Promise.allSettled(modulePromises.map((promiseFn) => promiseFn())).then(() => resolve()),
+  );

--- a/src/renderer/modules/common/index.ts
+++ b/src/renderer/modules/common/index.ts
@@ -9,7 +9,7 @@ function importTimeout<T>(name: string, moduleImport: Promise<T>, cb: (mod: T) =
         const timeout = setTimeout(() => {
           error("CommonModules", name, void 0, `Could not find module "${name}"`);
           rej(new Error(`Module not found: "${name}`));
-        }, 1_000);
+        }, 10_000);
         void moduleImport.then((mod) => {
           clearTimeout(timeout);
           cb(mod);


### PR DESCRIPTION
a potential fix for the ignition issue in replugged.


from what I suspect it was happening because all the promises in the modulePromises array were getting processed as soon as they were pushed to array instead of waiting for the ready function to be awaited in both common and components.
so they started to get processed as soon as you imported the index.ts of these respectively.

also, the ready function was being implicitly awaited while importing, making awaiting for it after webpack getting ready useless.

so I fixed this issue by wrapping it in a function which returns the promise.

also the hljs/typing/parser were giving error about being undefined even while being being defined which got fixed by increasing the timeout from 5 to 10 secs.

if it still gives an error in igniting then it the common and components are being awaited before your discord can load the components. One way to fix that is by waiting for them to load longer but waiting for most of the elements to load instead is a better option.
the only problem is plain text patches which depend on the plugin/coremods to be loaded as soon as discord is loaded, for example, the notice coremod, modified it to work even if the coremod loads later and some plugins might need to get modified like that too if we go with the route of waiting for most elements to load and then run.

well, I have added a waitFor in ignition.ignite if you wanna try that. it works on every screen discord can open up to so its good enough.
It's commented rn but you can uncomment it to test the theory. worked fine for me in my testing so far.
if you are gonna test the waitFor then if discord every time on startup, remove any plugins which have plain text patch

