### PR TITLE
Improvements to install links

### DIFF
--- a/src/renderer/coremods/installer/util.tsx
+++ b/src/renderer/coremods/installer/util.tsx
@@ -3,10 +3,11 @@ import { Messages } from "@common/i18n";
 import { Button, Notice } from "@components";
 import { Logger } from "@replugged";
 import { setUpdaterState } from "src/renderer/managers/updater";
+import { openExternal } from "src/renderer/util";
 import type { AnyAddonManifest, CheckResultSuccess } from "src/types";
 import * as pluginManager from "../../managers/plugins";
 import * as themeManager from "../../managers/themes";
-import { getAddonType, label } from "../settings/pages";
+import { getAddonType, getSourceLink, label } from "../settings/pages";
 
 const logger = Logger.coremod("Installer");
 
@@ -164,7 +165,10 @@ function authorList(authors: string[]): string {
   });
 }
 
-async function showInstallPrompt(manifest: AnyAddonManifest): Promise<boolean> {
+async function showInstallPrompt(
+  manifest: AnyAddonManifest,
+  linkToStore = true,
+): Promise<boolean | null> {
   let type: string;
   switch (manifest.type) {
     case "replugged-plugin":
@@ -181,6 +185,8 @@ async function showInstallPrompt(manifest: AnyAddonManifest): Promise<boolean> {
     name: manifest.name,
     authors,
   });
+
+  const storeUrl = linkToStore ? getSourceLink(manifest) : undefined;
 
   const res = await modal.confirm({
     title,
@@ -200,9 +206,11 @@ async function showInstallPrompt(manifest: AnyAddonManifest): Promise<boolean> {
     ),
     confirmText: Messages.REPLUGGED_CONFIRM,
     cancelText: Messages.REPLUGGED_CANCEL,
+    secondaryConfirmText: storeUrl ? Messages.REPLUGGED_INSTALLER_OPEN_STORE : undefined,
+    onConfirmSecondary: () => (storeUrl ? openExternal(storeUrl) : null),
   });
 
-  return res || false;
+  return res;
 }
 
 export type InstallResponse =
@@ -228,6 +236,8 @@ export type InstallResponse =
  * @param identifier Identifier for the addon in that source
  * @param source Updater source type
  * @param id Optional ID for the addon in that source. Useful for GitHub repositories that have multiple addons.
+ * @param showToasts Whether to show toasts (default: true)
+ * @param linkToStore Whether to link to the store page (default: true)
  * @returns
  */
 export async function installFlow(
@@ -235,6 +245,7 @@ export async function installFlow(
   source?: InstallerSource,
   id?: string,
   showToasts = true,
+  linkToStore = true,
 ): Promise<InstallResponse> {
   const info = await getInfo(identifier, source, id);
   if (!info) {
@@ -263,9 +274,12 @@ export async function installFlow(
 
   window.DiscordNative.window.focus();
 
-  const confirm = await showInstallPrompt(info.manifest);
+  const confirm = await showInstallPrompt(info.manifest, linkToStore);
   if (!confirm) {
-    toast.toast(Messages.REPLUGGED_TOAST_INSTALLER_ADDON_CANCELED_INSTALL, toast.Kind.MESSAGE);
+    if (confirm === false && showToasts) {
+      // Do not show if null ("open in store" clicked)
+      toast.toast(Messages.REPLUGGED_TOAST_INSTALLER_ADDON_CANCELED_INSTALL, toast.Kind.MESSAGE);
+    }
     return {
       kind: "CANCELLED",
       manifest: info.manifest,

--- a/src/renderer/coremods/settings/pages/Addons.tsx
+++ b/src/renderer/coremods/settings/pages/Addons.tsx
@@ -12,7 +12,7 @@ import {
   Tooltip,
 } from "@components";
 import type { RepluggedPlugin, RepluggedTheme } from "src/types";
-import type { Author } from "src/types/addon";
+import type { AnyAddonManifest, Author } from "src/types/addon";
 import "./Addons.css";
 import Icons from "../icons";
 import { Logger, plugins, themes, webpack } from "@replugged";
@@ -137,8 +137,8 @@ function getAuthors(addon: RepluggedPlugin | RepluggedTheme): Author[] {
   return [addon.manifest.author].flat();
 }
 
-function getSourceLink(addon: RepluggedPlugin | RepluggedTheme): string | undefined {
-  const { id: addonId, updater } = addon.manifest;
+export function getSourceLink(addon: AnyAddonManifest): string | undefined {
+  const { id: addonId, updater } = addon;
   if (!updater) return undefined;
   const { type, id: updaterId } = updater;
   switch (type) {
@@ -315,7 +315,7 @@ function Card({
   reload: () => void;
   uninstall: () => void;
 }): React.ReactElement {
-  const sourceLink = getSourceLink(addon);
+  const sourceLink = getSourceLink(addon.manifest);
 
   return (
     <div className="replugged-addon-card">


### PR DESCRIPTION
- Store links (https://replugged.dev/store/:id) will trigger install links
- Ctrl/cmd clicking an install link will bypass the modal and open the URL in the browser
- Add a button to the install modal to view the store page in your browser
![Screenshot on 2023-07-09 at 13 30 29](https://github.com/replugged-org/replugged/assets/14863373/994488a7-9d75-46b7-8834-632df5dc11e2)
