### PR TITLE
Remove old eslint disable lines

### DIFF
--- a/src/renderer/coremods/settings/pages/QuickCSS.tsx
+++ b/src/renderer/coremods/settings/pages/QuickCSS.tsx
@@ -80,9 +80,7 @@ function useCodeMirror({ value: initialValueParam, onChange, container }: UseCod
           css(),
           EditorView.updateListener.of((update) => {
             if (update.docChanged) {
-              // eslint-disable-next-line @typescript-eslint/no-base-to-string
               setValue(update.state.doc.toString());
-              // eslint-disable-next-line @typescript-eslint/no-base-to-string
               onChange?.(update.state.doc.toString());
             }
           }),


### PR DESCRIPTION
This pull request removes some old eslint-disable-next-line lines. There's not a whole lot to review but I thought I might as well PR it. 