### PR TITLE
feat(flux): add hooks and SnapshotStore

### DIFF
--- a/src/renderer/modules/common/flux.ts
+++ b/src/renderer/modules/common/flux.ts
@@ -160,7 +160,12 @@ export interface FluxMod {
 
 const FluxMod = await waitForProps<FluxMod>("Store", "connectStores");
 
-export declare class SnapshotStore<Snapshot = Record<string, unknown>> extends Store {
+interface Snapshot<Data> {
+  data: Data;
+  version: number;
+}
+
+export declare class SnapshotStore<Data = Record<string, unknown>> extends Store {
   public static allStores: SnapshotStore[];
 
   public static clearAll: () => void;
@@ -168,8 +173,8 @@ export declare class SnapshotStore<Snapshot = Record<string, unknown>> extends S
   public get persistKey(): string;
 
   public clear: () => void;
-  public getClass: () => typeof SnapshotStore;
-  public readSnapshot: (version: number) => Snapshot | null;
+  public getClass: () => any;
+  public readSnapshot: (version: number) => Snapshot<Data>["data"] | null;
   public registerActionHandlers: (actions: ActionHandlerRecord) => void;
   public save: () => void;
 }

--- a/src/renderer/modules/common/flux.ts
+++ b/src/renderer/modules/common/flux.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { Band, FluxDispatcher as Dispatcher } from "./fluxDispatcher";
-import { waitForProps } from "../webpack";
+import { filters, getFunctionBySource, waitForModule, waitForProps } from "../webpack";
 
 type DispatchToken = string;
 type ActionType = string;
@@ -141,7 +141,7 @@ export declare class PersistedStore extends Store {
 export type DeviceSettingsStore = typeof PersistedStore;
 export type OfflineCacheStore = typeof PersistedStore;
 
-export interface Flux {
+export interface FluxMod {
   DeviceSettingsStore: DeviceSettingsStore;
   Emitter: Emitter;
   OfflineCacheStore: OfflineCacheStore;
@@ -158,4 +158,54 @@ export interface Flux {
   get initialized(): Promise<boolean | undefined>;
 }
 
-export default await waitForProps<Flux>("Store", "connectStores");
+const FluxMod = await waitForProps<FluxMod>("Store", "connectStores");
+
+export declare class SnapshotStore<Snapshot = Record<string, unknown>> extends Store {
+  public static allStores: SnapshotStore[];
+
+  public static clearAll: () => void;
+
+  public get persistKey(): string;
+
+  public clear: () => void;
+  public getClass: () => typeof SnapshotStore;
+  public readSnapshot: (version: number) => Snapshot | null;
+  public registerActionHandlers: (actions: ActionHandlerRecord) => void;
+  public save: () => void;
+}
+
+const SnapshotStoreClass = await waitForModule<typeof SnapshotStore>(
+  filters.bySource("SnapshotStores"),
+);
+
+export interface FluxHooks {
+  useStateFromStores: <T>(
+    stores: Store[],
+    callback: () => T,
+    deps?: React.DependencyList,
+    compare?: (a: T, b: T) => boolean,
+  ) => T;
+  statesWillNeverBeEqual: <T>(a: T, b: T) => boolean;
+  useStateFromStoresArray: <T>(
+    stores: Store[],
+    callback: () => T,
+    deps?: React.DependencyList,
+  ) => T;
+  useStateFromStoresObject: <T>(
+    stores: Store[],
+    callback: () => T,
+    deps?: React.DependencyList,
+  ) => T;
+}
+
+const FluxHooksMod = await waitForModule(filters.bySource("useStateFromStores"));
+const FluxHooks = {
+  useStateFromStores: getFunctionBySource(FluxHooksMod, "useStateFromStores"),
+  statesWillNeverBeEqual: getFunctionBySource(FluxHooksMod, "return!1"),
+  useStateFromStoresArray: getFunctionBySource(FluxHooksMod, /return \w\(.{0,7}\.\w\)/),
+  useStateFromStoresObject: getFunctionBySource(FluxHooksMod, /return \w\(.{0,7}\)/),
+};
+
+export type Flux = FluxMod & { SnapshotStore: typeof SnapshotStore } & FluxHooks;
+
+export default { ...FluxMod, SnapshotStore: SnapshotStoreClass, ...FluxHooks } as Flux;


### PR DESCRIPTION
Adds to `common.flux`:
- `useStateFromStores`, `statesWillNeverBeEqual`, `useStateFromStoresArray`, `useStateFromStoresObject`
- `SnapshotStore`