### PR TITLE
Remove line breaks in plaintext patches

### DIFF
--- a/src/renderer/modules/webpack/plaintext-patch.ts
+++ b/src/renderer/modules/webpack/plaintext-patch.ts
@@ -11,7 +11,7 @@ export const plaintextPatches: RawPlaintextPatch[] = [];
  * @returns Patched module
  */
 export function patchModuleSource(mod: WebpackModule): WebpackModule {
-  const originalSource = mod.toString();
+  const originalSource = mod.toString().replaceAll("\n", "");
 
   const patchedSource = plaintextPatches.reduce((source, patch) => {
     if (


### PR DESCRIPTION
removes all line breaks from code in plain text patch. wouldnt break anything since minified codes work fine without line breaks