### PR TITLE
Track install type and version

### DIFF
--- a/src/main/ipc/installer.ts
+++ b/src/main/ipc/installer.ts
@@ -166,10 +166,16 @@ ipcMain.handle(
     type: InstallerType | "replugged",
     path: string,
     url: string,
+    update: boolean,
+    version?: string,
   ): Promise<InstallResultSuccess | InstallResultFailure> => {
+    const query = new URLSearchParams();
+    query.set("type", update ? "update" : "install");
+    if (version) query.set("version", version);
+
     let res;
     try {
-      res = await fetch(url);
+      res = await fetch(`${url}?${query}`);
     } catch (err) {
       return {
         success: false,

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -68,8 +68,9 @@ const RepluggedNative = {
       type: InstallerType,
       path: string,
       url: string,
+      version: string,
     ): Promise<InstallResultSuccess | InstallResultFailure> =>
-      ipcRenderer.invoke(RepluggedIpcChannels.INSTALL_ADDON, type, path, url, false),
+      ipcRenderer.invoke(RepluggedIpcChannels.INSTALL_ADDON, type, path, url, false, version),
   },
 
   quickCSS: {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -52,8 +52,9 @@ const RepluggedNative = {
       type: InstallerType | "replugged",
       path: string,
       url: string,
+      version: string,
     ): Promise<InstallResultSuccess | InstallResultFailure> =>
-      ipcRenderer.invoke(RepluggedIpcChannels.INSTALL_ADDON, type, path, url),
+      ipcRenderer.invoke(RepluggedIpcChannels.INSTALL_ADDON, type, path, url, true, version),
   },
 
   installer: {
@@ -68,7 +69,7 @@ const RepluggedNative = {
       path: string,
       url: string,
     ): Promise<InstallResultSuccess | InstallResultFailure> =>
-      ipcRenderer.invoke(RepluggedIpcChannels.INSTALL_ADDON, type, path, url),
+      ipcRenderer.invoke(RepluggedIpcChannels.INSTALL_ADDON, type, path, url, false),
   },
 
   quickCSS: {

--- a/src/renderer/coremods/installer/util.tsx
+++ b/src/renderer/coremods/installer/util.tsx
@@ -101,7 +101,12 @@ export async function install(data: CheckResultSuccess): Promise<boolean> {
     manifest: { name, type, id, version },
   } = data;
 
-  const res = await RepluggedNative.installer.install(type, `${id}.asar`, url);
+  const res = await RepluggedNative.installer.install(
+    type,
+    `${id}.asar`,
+    url,
+    data.manifest.version,
+  );
   if (!res.success) {
     logger.error(`Failed to install ${name}: ${res.error}`);
     toast.toast(

--- a/src/renderer/managers/updater.ts
+++ b/src/renderer/managers/updater.ts
@@ -185,6 +185,7 @@ export async function installUpdate(id: string, force = false, verbose = true): 
     entity.manifest.type,
     entity.path,
     updateSettings.url,
+    updateSettings.version,
   );
 
   if (!res.success) {


### PR DESCRIPTION
Add the install type and version in the query string when updating an addon. This will allow us to track download counts for the store. Backend code still needs to be updated, but will go ahead and get this out there for the next update so we can start tracking.