### PR TITLE
Better implementation of useStateFromStoresArray and useStateFromStoresObject

### DIFF
--- a/src/renderer/modules/common/flux.ts
+++ b/src/renderer/modules/common/flux.ts
@@ -183,29 +183,6 @@ const SnapshotStoreClass = await waitForModule<typeof SnapshotStore>(
   filters.bySource("SnapshotStores"),
 );
 
-function shallowEqual<T extends Record<string, unknown>>(a: T, b: T): boolean {
-  if (a === b) return true;
-
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
-
-  if (keysA.length !== keysB.length) return false;
-
-  for (let i = 0; i < keysA.length; i++) {
-    let key = keysA[i];
-    if (a[key] !== b[key]) return false;
-  }
-
-  return true;
-}
-
-function areArraysShallowEqual<T extends []>(a: T, b: T): boolean {
-  if (b == null || a.length !== b.length) return false;
-  return !a.some(function (value, index) {
-    return b[index] !== value;
-  });
-}
-
 type useStateFromStores = <T>(
   stores: Store[],
   callback: () => T,
@@ -237,9 +214,9 @@ const statesWillNeverBeEqual = getFunctionBySource<statesWillNeverBeEqual>(
   "return!1",
 )!;
 const useStateFromStoresArray: useStateFromStoresArray = (stores, callback, deps) =>
-  useStateFromStores(stores, callback, deps, areArraysShallowEqual);
+  useStateFromStores(stores, callback, deps, _.isEqual);
 const useStateFromStoresObject: useStateFromStoresObject = (stores, callback, deps) =>
-  useStateFromStores(stores, callback, deps, shallowEqual);
+  useStateFromStores(stores, callback, deps, _.isEqual);
 
 const FluxHooks = {
   useStateFromStores,

--- a/src/renderer/modules/common/messages.ts
+++ b/src/renderer/modules/common/messages.ts
@@ -151,10 +151,7 @@ declare class MessageCache {
   public clone: () => MessageCache;
   public extract: (amount: number) => Message[];
   public extractAll: () => Message[];
-  public forEach: (
-    callback: (message: Message, index: number, messages: Message[]) => void,
-    thisArg?: unknown,
-  ) => void;
+  public forEach: Message[]["forEach"];
   public get: (messageId: string) => Message | undefined;
   public has: (messageId: string) => boolean;
   public remove: (messageId: string) => void;
@@ -242,10 +239,7 @@ export declare class ChannelMessages {
   ) => Message | undefined;
   public first: () => Message | undefined;
   public focusOnMessage: (focusTargetId: string) => ChannelMessages;
-  public forAll: (
-    callback: (message: Message, index: number, messages: Message[]) => void,
-    thisArg?: unknown,
-  ) => void;
+  public forAll: Array<Message | MessageCache>["forEach"];
   public forEach: (
     callback: (message: Message, index: number, messages: Message[]) => void,
     thisArg?: unknown,
@@ -286,10 +280,7 @@ export declare class ChannelMessages {
     offset: number;
     returnMessageId: string;
   }) => ChannelMessages;
-  public map: (
-    callback: (message: Message, index: number, messages: Message[]) => Message,
-    thisArg?: unknown,
-  ) => Message[];
+  public map: Message[]["map"];
   public merge: (messages: Message[], prepend?: boolean, clearCache?: boolean) => ChannelMessages;
   public mergeDelta: (
     newMessages?: Message[],
@@ -302,15 +293,8 @@ export declare class ChannelMessages {
   ) => ChannelMessages;
   public receiveMessage: (message: Message, truncateFromTop?: boolean) => ChannelMessages;
   public receivePushNotification: (message: Message) => ChannelMessages;
-  public reduce: (
-    callback: (
-      previousValue: unknown,
-      currentMessage: Message,
-      currentIndex: number,
-      messages: Message[],
-    ) => unknown,
-    initialValue?: unknown,
-  ) => void;
+  public reduce: Message[]["reduce"];
+  public some: Message[]["some"];
   public remove: (messageId: string) => ChannelMessages;
   public removeMany: (messageIds: string[]) => ChannelMessages;
   public replace: (prevMessageId: string, newMessage: Message) => ChannelMessages;

--- a/src/types/coremods/contextMenu.ts
+++ b/src/types/coremods/contextMenu.ts
@@ -26,6 +26,7 @@ export type GetContextItem<T extends Record<string, unknown> = Record<string, un
 export enum ContextMenuTypes {
   /** Click the user icon in the bottom left */
   Account = "account",
+  ActivityShelfItemContext = "activity-shelf-item-context",
   AddQuestions = "add-questions",
   ApplicationDirectoryProfile = "application-directory-profile",
   /** Right-click mute or deafen buttons */
@@ -64,21 +65,28 @@ export enum ContextMenuTypes {
   /** Dropdown under a server's name */
   GuildHeaderPopout = "guild-header-popout",
   GuildIntegrationsPermissionRoleContext = "guild-integrations-permission-role-context",
+  GuildModerationRoles = "guild-moderation-roles",
+  GuildProductContext = "guild-product-context",
   GuildRoleConnectionsContext = "guild-role-connections-context",
   /** Right-click a role in the guild settings */
   GuildSettingsRoleContext = "guild-settings-role-context",
+  GuildShopContext = "guild-shop-context",
   ImageContext = "image-context",
   JoinRequestGuildContext = "join-request-guild-context",
   LaunchContext = "launch-context",
+  ManageBroadcast = "manage-broadcast",
   ManageIntegration = "manage-integration",
   ManageMultiAccount = "manage-multi-account",
   ManageStreams = "manage-streams",
   MemberApplicationContextMenu = "member-application-context-menu",
+  MemberSafetyFlags = "member-safety-flags",
+  MemberSafetyOptions = "member-safety-options",
   MentionsFilter = "mentions-filter",
-  /** Right-click message */
-  Message = "message",
   /** Click the triple dots on a message popover */
   MessageActions = "message-actions",
+  MessageReminderSnooze = "message-reminder-snooze",
+  /** Right-click message */
+  Message = "message",
   ModerationRaidContext = "moderation-raid-context",
   NotificationActions = "notification-actions",
   NowPlayingMenu = "now-playing-menu",
@@ -91,6 +99,7 @@ export enum ContextMenuTypes {
   RoleSubscriptionContext = "role-subscription-context",
   RtcChannel = "rtc-channel",
   SearchResults = "search-results",
+  SetImageForAction = "set-image-for-action",
   SortAndView = "sort-and-view",
   SoundButtonContext = "sound-button-context",
   StaffHelpPopout = "staff-help-popout",


### PR DESCRIPTION
`useStateFromStoresArray` recently became undefined and together with `useStateFromStoresObject` both had an unstable regex. ~~Recreating the function used by the original hooks should be better.~~ Uses Lodash's `isEqual` function.

Includes updated types for `ChannelMessages` and new navIds for `ContextMenuTypes` enum.