### PR TITLE
Update fluxDispatcher.ts

### DIFF
--- a/src/renderer/modules/common/fluxDispatcher.ts
+++ b/src/renderer/modules/common/fluxDispatcher.ts
@@ -99,7 +99,7 @@ declare class ActionHandlers {
 
   public addDependencies: (token: string, tokens: string) => void;
   public createToken: () => string;
-  public getOrderedActionHandlers: (action: Action) => void;
+  public getOrderedActionHandlers: (action: Action) => Handler[];
   public register: (
     name: string,
     actionHandler: Record<string, FluxCallback>,


### PR DESCRIPTION
`fluxDispatcher._actionHandlers.getOrderedActionHandlers` returns an array of Handlers, not `void`

![image](https://github.com/replugged-org/replugged/assets/84055084/971692ce-44ce-4a8c-873a-02c0141cc2d9)
![image](https://github.com/replugged-org/replugged/assets/84055084/2618a81b-0ff2-4e67-b018-f10caa3982be)
