### PR TITLE
Install embed fixes

### DIFF
--- a/src/renderer/coremods/installer/index.tsx
+++ b/src/renderer/coremods/installer/index.tsx
@@ -162,6 +162,7 @@ async function injectLinks(): Promise<void> {
       if (!match) return null;
       const installLink = parseInstallLink(match[1]);
       if (!installLink) return null;
+      if (installLink.source !== "store") return null;
       if (!generalSettings.get("addonEmbeds")) return null;
       return match;
     },


### PR DESCRIPTION
- Do not show addon embeds for non-store addons (it was supposed to do this in the first place)
- Cache when an addon fails to fetch