### PR TITLE
fix: addon embed authors overflow

### DIFF
--- a/src/renderer/coremods/installer/AddonEmbed.tsx
+++ b/src/renderer/coremods/installer/AddonEmbed.tsx
@@ -151,17 +151,18 @@ const Embed = React.memo(
             <div className={barLoader} />
           ) : (
             <>
-              <strong className={title}>{props.authors}</strong>
+              <Tooltip text={props.authors} className="replugged-addon-embed-title-tooltip">
+                <strong className={`${title} replugged-addon-embed-title`}>{props.authors}</strong>
+              </Tooltip>
               <Clickable
-                className={`${copyLink}`}
-                style={{
-                  paddingRight: "0px",
-                }}
+                className={`${copyLink} replugged-addon-embed-store-button`}
                 onClick={() => openExternal(props.url)}>
                 {Messages.REPLUGGED_INSTALLER_OPEN_STORE}
               </Clickable>
               <Clickable
-                className={`${copyLink}${props.onCooldown ? ` ${copied} addon-embed-copied` : ""}`}
+                className={`${copyLink} replugged-addon-embed-copy-button${
+                  props.onCooldown ? ` ${copied} addon-embed-copied` : ""
+                }`}
                 onClick={props.copyUrl}>
                 <Link className={copyLinkIcon} />
                 {props.onCooldown

--- a/src/renderer/coremods/installer/addonEmbed.css
+++ b/src/renderer/coremods/installer/addonEmbed.css
@@ -25,3 +25,22 @@ div[class] .addon-embed-copied:hover {
 .replugged-addon-embed-button {
   flex: 1;
 }
+
+.replugged-addon-embed-title-tooltip {
+  overflow: hidden;
+}
+
+.replugged-addon-embed-title {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.replugged-addon-embed-store-button {
+  padding-right: 0px;
+  flex: none;
+}
+
+.replugged-addon-embed-copy-button {
+  flex: none;
+}


### PR DESCRIPTION
Fixes an issue with authors showing on the addon embed. Now the text is trimmed like the description and has a tooltip to show all authors.