### PR TITLE
Fix install warning for un-reviewed addon

### DIFF
--- a/src/renderer/coremods/installer/util.tsx
+++ b/src/renderer/coremods/installer/util.tsx
@@ -14,6 +14,7 @@ const logger = Logger.coremod("Installer");
 // First item is the default
 const INSTALLER_SOURCES = ["store", "github"] as const;
 export type InstallerSource = (typeof INSTALLER_SOURCES)[number];
+const DEFAULT_INSTALLER_SOURCE: InstallerSource = "store";
 
 const CACHE_INTERVAL = 1000 * 60 * 60;
 
@@ -29,7 +30,7 @@ export async function getInfo(
   source?: InstallerSource,
   id?: string,
 ): Promise<CheckResultSuccess | null> {
-  source ??= INSTALLER_SOURCES[0];
+  source ??= DEFAULT_INSTALLER_SOURCE;
 
   const cacheIdentifier = `${source}:${identifier}:${id ?? ""}`;
   const cached = cache.get(cacheIdentifier);
@@ -176,6 +177,7 @@ export function authorList(authors: string[]): string {
 
 async function showInstallPrompt(
   manifest: AnyAddonManifest,
+  source: InstallerSource | undefined,
   linkToStore = true,
 ): Promise<boolean | null> {
   let type: string;
@@ -202,7 +204,7 @@ async function showInstallPrompt(
     body: (
       <>
         {text}
-        {manifest.updater?.type !== "store" ? (
+        {(source ?? DEFAULT_INSTALLER_SOURCE) !== "store" ? (
           <div style={{ marginTop: "16px" }}>
             <Notice messageType={Notice.Types.ERROR}>
               {Messages.REPLUGGED_ADDON_NOT_REVIEWED_DESC.format({
@@ -283,7 +285,7 @@ export async function installFlow(
 
   window.DiscordNative.window.focus();
 
-  const confirm = await showInstallPrompt(info.manifest, linkToStore);
+  const confirm = await showInstallPrompt(info.manifest, source, linkToStore);
   if (!confirm) {
     if (confirm === false && showToasts) {
       // Do not show if null ("open in store" clicked)


### PR DESCRIPTION
The warning for installing an addon that's not from the store was using the manifest's updater source to determine that, which means an addon not from the store could trick the warning by just claiming they're from the store even if they're not. To fix this, we now use the actual install source to determine it, which can't be faked.