### PR TITLE
fix(openExternal): use correct module

### DIFF
--- a/src/renderer/modules/common/channels.ts
+++ b/src/renderer/modules/common/channels.ts
@@ -8,7 +8,7 @@ interface LastChannelFollowingDestination {
 }
 
 export interface SelectedChannelStore {
-  getChannelId: (guildId: string, fallbackToDefault?: boolean) => string | undefined;
+  getChannelId: (guildId?: string, fallbackToDefault?: boolean) => string | undefined;
   getCurrentlySelectedChannelId: (guildId?: string) => string | undefined;
   getLastChannelFollowingDestination: () => LastChannelFollowingDestination;
   getLastSelectedChannelId: (guildId?: string) => string | undefined;

--- a/src/renderer/modules/components/Modal.tsx
+++ b/src/renderer/modules/components/Modal.tsx
@@ -32,6 +32,7 @@ interface ModalHeaderProps {
 interface ModalContentProps extends React.ComponentPropsWithoutRef<"div"> {
   children: React.ReactNode;
   scrollerRef?: React.Ref<unknown>;
+  scrollbarType?: "auto" | "none" | "thin";
 }
 
 interface ModalFooterProps extends ModalHeaderProps {}

--- a/src/renderer/modules/components/Tooltip.tsx
+++ b/src/renderer/modules/components/Tooltip.tsx
@@ -38,7 +38,6 @@ interface BaseTooltipProps {
   allowOverflow?: boolean;
   disableTooltipPointerEvents?: boolean;
   forceOpen?: boolean;
-  hide?: boolean;
   hideOnClick?: boolean;
   clickableOnMobile?: boolean;
   shouldShow?: boolean;

--- a/src/renderer/util.ts
+++ b/src/renderer/util.ts
@@ -171,7 +171,7 @@ export async function goToOrJoinServer(invite: string): Promise<void> {
 }
 
 export async function openExternal(url: string): Promise<void> {
-  const mod = getBySource<(url: string) => Promise<void>>('.target="_blank"');
+  const mod = getBySource<(url: string) => Promise<void>>(/href=\w;\w\.target="_blank"/);
   if (!mod) {
     throw new Error("Could not find openExternal");
   }


### PR DESCRIPTION
`util.openExternal` is erroring due to using the wrong module.

Includes updated types for `channels`, `Modal` and `Tooltip`.