### PR TITLE
Fix ignition plugin timeout

### DIFF
--- a/src/renderer/managers/ignition.ts
+++ b/src/renderer/managers/ignition.ts
@@ -1,5 +1,5 @@
 import { signalStart, waitForReady } from "../modules/webpack/patch-load";
-import { log } from "../modules/logger";
+import { error, log } from "../modules/logger";
 
 import { ready as commonReady } from "@common";
 import { ready as componentsReady } from "../modules/components";
@@ -17,11 +17,26 @@ export async function start(): Promise<void> {
 
   loadStyleSheet("replugged://renderer.css");
   i18n.load();
-  await Promise.all([
-    coremods.startAll(),
-    plugins.startAll(),
-    themes.loadMissing().then(themes.loadAll),
+
+  let started = false;
+  await Promise.race([
+    Promise.allSettled([
+      coremods.startAll(),
+      plugins.startAll(),
+      themes.loadMissing().then(themes.loadAll),
+    ]),
+    // Failsafe to ensure that we always start Replugged
+    new Promise((resolve) =>
+      setTimeout(() => {
+        if (!started) {
+          error("Ignition", "Start", void 0, "Ignition timed out after 10 seconds");
+          resolve(void 0);
+        }
+      }, 10_000),
+    ),
   ]);
+  started = true;
+
   // Quick CSS needs to be called after themes are loaded so that it will override the theme's CSS
   quickCSS.load();
 

--- a/src/renderer/managers/plugins.ts
+++ b/src/renderer/managers/plugins.ts
@@ -76,15 +76,17 @@ export async function start(id: string): Promise<void> {
     }
 
     if (plugin.manifest.renderer) {
-      plugin.exports = await import(
-        `replugged://plugin/${plugin.path}/${plugin.manifest.renderer}?t=${Date.now()}}`
-      );
-
       await Promise.race([
         new Promise((_, reject) =>
           setTimeout(() => reject(new Error("Plugin took too long to start")), 5_000),
         ),
-        plugin.exports!.start?.(),
+        (async () => {
+          const pluginExports = await import(
+            `replugged://plugin/${plugin.path}/${plugin.manifest.renderer}?t=${Date.now()}}`
+          );
+          plugin.exports = pluginExports;
+          await pluginExports.start?.();
+        })(),
       ]);
     }
 


### PR DESCRIPTION
If a plugin used top-level await, that would not be included in the startup timeout, causing it to block startup potentially indefinitely. Also added a failsafe to ignition that will proceed if coremod/plugin/theme startup takes more than 10 seconds.