### PR TITLE
Proper imports from types package

### DIFF
--- a/bin/replugged.mjs
+++ b/bin/replugged.mjs
@@ -257,20 +257,7 @@ async function buildPlugin({ watch, noInstall, production, noReload }) {
     // @ts-expect-error
     setup: (build) => {
       // @ts-expect-error
-      build.onResolve({ filter: /^replugged.+$/ }, (args) => {
-        if (args.kind !== "import-statement") return undefined;
-
-        return {
-          errors: [
-            {
-              text: `Importing from a path (${args.path}) is not supported. Instead, please import from "replugged" and destructure the required modules.`,
-            },
-          ],
-        };
-      });
-
-      // @ts-expect-error
-      build.onResolve({ filter: /^replugged$/ }, (args) => {
+      build.onResolve({ filter: /^replugged(\/\w+)?$/ }, (args) => {
         if (args.kind !== "import-statement") return undefined;
 
         return {
@@ -284,9 +271,10 @@ async function buildPlugin({ watch, noInstall, production, noReload }) {
           filter: /.*/,
           namespace: "replugged",
         },
-        () => {
+        // @ts-expect-error
+        (loadArgs) => {
           return {
-            contents: "module.exports = window.replugged",
+            contents: `module.exports = window.${loadArgs.path.replace("/", ".")}`,
           };
         },
       );

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "eslint:fix": "eslint ./src ./scripts ./bin --fix",
     "lint": "pnpm run prettier:check && pnpm run eslint:check && pnpm run cspell:check && pnpm run typescript:check",
     "lint:fix": "pnpm run prettier:fix && pnpm run eslint:fix && pnpm run cspell:check && pnpm run typescript:check",
-    "prepublishOnly": "rm -rf dist; tsc --declaration --emitDeclarationOnly --noEmit false -p tsconfig.json --outDir dist; rm -rf dist/scripts; mv dist/src/* dist; rm -rf dist/src; cp src/*.d.ts dist",
-    "postpublish": "rm -rf dist; npm run build",
+    "prepublishOnly": "rm -rf dist; tsc --declaration --emitDeclarationOnly --noEmit false -p tsconfig.json --outDir dist; rm -rf dist/scripts; mv dist/src/* dist; rm -rf dist/src; cp src/*.d.ts dist; tsx scripts/create-import-wrappers.mts",
+    "postpublish": "rm *.d.ts; rm -rf dist; npm run build",
     "docs": "typedoc src/renderer/replugged.ts --excludeExternals",
     "docs:watch": "pnpm run docs --watch"
   },
@@ -70,7 +70,8 @@
   },
   "files": [
     "dist",
-    "bin"
+    "bin",
+    "*.d.ts"
   ],
   "dependencies": {
     "@codemirror/lang-css": "^6.2.1",

--- a/scripts/create-import-wrappers.mts
+++ b/scripts/create-import-wrappers.mts
@@ -1,0 +1,15 @@
+import { writeFileSync } from "node:fs";
+
+const locations = {
+  modules: ["logger", "webpack", "i18n", "injector", "common", "components"],
+  apis: ["commands", "notices", "settings"],
+  util: ["util"],
+};
+
+for (const [category, names] of Object.entries(locations)) {
+  for (const name of names) {
+    const path = `./dist/renderer/${category}/${name}`;
+    const dtsContents = `import * as exp from "${path}"; export = exp;`;
+    writeFileSync(`${name}.d.ts`, dtsContents);
+  }
+}


### PR DESCRIPTION
Allows plugin devs to import things from replugged's types package and have those imports transformed to references to window.replugged seamlessly. No more importing and then destructuring. Closes #247.