### PR TITLE
Fix Discord crash

### DIFF
--- a/src/renderer/modules/common/index.ts
+++ b/src/renderer/modules/common/index.ts
@@ -10,11 +10,16 @@ function importTimeout<T>(name: string, moduleImport: Promise<T>, cb: (mod: T) =
           error("CommonModules", name, void 0, `Could not find module "${name}"`);
           rej(new Error(`Module not found: "${name}`));
         }, 10_000);
-        void moduleImport.then((mod) => {
-          clearTimeout(timeout);
-          cb(mod);
-          res();
-        });
+        void moduleImport
+          .then((mod) => {
+            clearTimeout(timeout);
+            cb(mod);
+            res();
+          })
+          .catch((err) => {
+            error("CommonModules", name, void 0, `Failed to import module "${name}"`, err);
+            rej(err);
+          });
       }),
   );
 }

--- a/src/renderer/modules/components/TextInput.tsx
+++ b/src/renderer/modules/components/TextInput.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { filters, waitForModule } from "../webpack";
+import { waitForProps } from "../webpack";
 
 interface TextInputProps
   extends Omit<React.ComponentPropsWithoutRef<"input">, "size" | "onChange"> {
@@ -19,8 +19,6 @@ export type TextInputType = React.ComponentClass<TextInputProps> & {
   Sizes: Record<"DEFAULT" | "MINI", string>;
 };
 
-export default await waitForModule<Record<string, TextInputType>>(
-  filters.bySource(".getIsOverFlowing"),
-).then(
-  (mod) => Object.values(mod).find((x) => "defaultProps" in x && "maxLength" in x.defaultProps)!,
+export default await waitForProps<Record<"TextInput", TextInputType>>("TextInput").then(
+  (x) => x.TextInput,
 );

--- a/src/renderer/modules/components/index.ts
+++ b/src/renderer/modules/components/index.ts
@@ -15,11 +15,16 @@ function importTimeout<T extends ModuleExports>(
           error("Components", name, void 0, `Could not find component "${name}"`);
           rej(new Error(`Module not found: "${name}`));
         }, 10_000);
-        void moduleImport.then((mod) => {
-          clearTimeout(timeout);
-          cb(mod);
-          res();
-        });
+        void moduleImport
+          .then((mod) => {
+            clearTimeout(timeout);
+            cb(mod);
+            res();
+          })
+          .catch((err) => {
+            error("Components", name, void 0, `Failed to import component "${name}"`, err);
+            rej(err);
+          });
       }),
   );
 }


### PR DESCRIPTION
- Fix selector for `TextInput` causing a crash
- Handle failed imports for components and common so that if this happens again it won't be a full client crash