### PR TITLE
Fix command type import

### DIFF
--- a/src/renderer/modules/injector.ts
+++ b/src/renderer/modules/injector.ts
@@ -1,4 +1,4 @@
-import type { CommandOptions, RepluggedCommand } from "src/types";
+import type { CommandOptions, RepluggedCommand } from "../../types";
 import type { ContextMenuTypes, GetContextItem } from "../../types/coremods/contextMenu";
 import type { GetButtonItem } from "../../types/coremods/message";
 import type { AnyFunction } from "../../types/util";

--- a/src/renderer/modules/injector.ts
+++ b/src/renderer/modules/injector.ts
@@ -1,4 +1,5 @@
-import type { CommandOptions, RepluggedCommand } from "../../types";
+import type { CommandOptions } from "../../types/discord";
+import type { RepluggedCommand } from "../../types/coremods/commands";
 import type { ContextMenuTypes, GetContextItem } from "../../types/coremods/contextMenu";
 import type { GetButtonItem } from "../../types/coremods/message";
 import type { AnyFunction } from "../../types/util";


### PR DESCRIPTION
This is a really tiny pr that fixes auto completion for commands. 

Basically, I was running into an issue when writing with `Injector.utils.registerSlashCommand` - it was just not doing type checking. However, when importing the types using a relative import, it just works. 

Why? I have no clue, just typescript being typescript or whatever. All I can say is that this fixes it. The fact that `src/types` doesn't just work could have wider implications on other parts of the codebase, but honestly I have no clue and nothing has come up yet so maybe not