### PR TITLE
Theme Presets

### DIFF
--- a/bin/index.mts
+++ b/bin/index.mts
@@ -21,7 +21,6 @@ import { logBuildPlugin } from "../src/util.mjs";
 import { sassPlugin } from "esbuild-sass-plugin";
 import { fileURLToPath } from "url";
 import { AddonType, getAddonFolder, isMonoRepo, selectAddon } from "./mono.mjs";
-import { ThemeManifest } from "src/types";
 
 interface BaseArgs {
   watch?: boolean;

--- a/bin/index.mts
+++ b/bin/index.mts
@@ -21,6 +21,7 @@ import { logBuildPlugin } from "../src/util.mjs";
 import { sassPlugin } from "esbuild-sass-plugin";
 import { fileURLToPath } from "url";
 import { AddonType, getAddonFolder, isMonoRepo, selectAddon } from "./mono.mjs";
+import { ThemeManifest } from "src/types";
 
 interface BaseArgs {
   watch?: boolean;
@@ -421,7 +422,9 @@ async function buildTheme({ watch, noInstall, production, noReload, addon }: Arg
   const distPath = addon ? `dist/${manifest.id}` : "dist";
   const folderPath = addon ? path.join(directory, "themes", addon) : directory;
 
-  const main = path.join(folderPath, manifest.main || "src/main.css");
+  const main = existsSync(path.join(folderPath, manifest.main || "src/main.css"))
+    ? path.join(folderPath, manifest.main || "src/main.css")
+    : undefined;
   const splash = existsSync(path.join(folderPath, manifest.splash || "src/main.css"))
     ? path.join(folderPath, manifest.splash || "src/main.css")
     : undefined;
@@ -483,6 +486,21 @@ async function buildTheme({ watch, noInstall, production, noReload, addon }: Arg
     );
 
     manifest.plaintextPatches = "splash.css";
+  }
+
+  if (manifest.presets) {
+    targets.push(
+      esbuild.context({
+        ...common,
+        entryPoints: manifest.presets.map((p: Record<string, string>) => p.path),
+        outdir: `${distPath}/presets`,
+      }),
+    );
+
+    manifest.presets = manifest.presets?.map((p: Record<string, string>) => ({
+      ...p,
+      path: `presets/${path.basename(p.path).split(".")[0]}.css`,
+    }));
   }
 
   if (!existsSync(distPath)) mkdirSync(distPath, { recursive: true });

--- a/cspell.json
+++ b/cspell.json
@@ -45,6 +45,7 @@
     "notif",
     "notrack",
     "outfile",
+    "outdir",
     "popout",
     "postpublish",
     "Promisable",

--- a/src/main/ipc/themes.ts
+++ b/src/main/ipc/themes.ts
@@ -30,6 +30,7 @@ async function getTheme(path: string): Promise<RepluggedTheme> {
       encoding: "utf-8",
     }),
   );
+  console.log(manifest);
 
   return {
     path,

--- a/src/renderer/coremods/settings/pages/Addons.tsx
+++ b/src/renderer/coremods/settings/pages/Addons.tsx
@@ -702,7 +702,7 @@ export const Addons = (type: AddonType): React.ReactElement => {
           </Text>
         ) : null
       ) : (
-        (SettingsElement = getSettingsElement(section.slice(`rp_${type}_`.length+1), type)) && (
+        (SettingsElement = getSettingsElement(section.slice(`rp_${type}_`.length + 1), type)) && (
           <ErrorBoundary>
             <SettingsElement />
           </ErrorBoundary>

--- a/src/renderer/coremods/settings/pages/Addons.tsx
+++ b/src/renderer/coremods/settings/pages/Addons.tsx
@@ -7,6 +7,7 @@ import {
   ErrorBoundary,
   Flex,
   Notice,
+  SelectItem,
   Switch,
   Text,
   TextInput,
@@ -84,6 +85,28 @@ function getSettingsElement(id: string, type: AddonType): React.ComponentType | 
     return plugins.getExports(id)?.Settings;
   }
   if (type === AddonType.Theme) {
+    let settings = themes.settings.get(id, { chosenPreset: undefined });
+    const theme = themes.themes.get(id)!;
+    if (theme.manifest.presets?.length) {
+      return () => (
+        <SelectItem
+          options={theme.manifest.presets!.map((preset) => ({
+            label: preset.label,
+            value: preset.path,
+          }))}
+          onChange={(val) => {
+            settings.chosenPreset = val;
+            themes.settings.set(id, settings);
+            if (!themes.getDisabled().includes(id)) {
+              themes.reload(id);
+            }
+          }}
+          isSelected={(val) => settings.chosenPreset === val}
+          closeOnSelect={true}>
+          Choose Theme Flavor
+        </SelectItem>
+      );
+    }
     return undefined;
   }
 
@@ -679,7 +702,7 @@ export const Addons = (type: AddonType): React.ReactElement => {
           </Text>
         ) : null
       ) : (
-        (SettingsElement = getSettingsElement(section.slice(`rp_${type}_`.length), type)) && (
+        (SettingsElement = getSettingsElement(section.slice(`rp_${type}_`.length+1), type)) && (
           <ErrorBoundary>
             <SettingsElement />
           </ErrorBoundary>

--- a/src/renderer/managers/themes.ts
+++ b/src/renderer/managers/themes.ts
@@ -49,17 +49,15 @@ export function load(id: string): void {
   const theme = themes.get(id)!;
   let themeSettings = settings.get(theme.manifest.id);
   if (!themeSettings) themeSettings = {};
-  console.log(themeSettings);
   if (!themeSettings.chosenPreset) {
     themeSettings.chosenPreset = theme.manifest.presets?.find((x) => x.default)?.path;
-    console.log(themeSettings);
     settings.set(theme.manifest.id, themeSettings);
   }
 
   let el;
   if (theme.manifest.main) {
     el = loadStyleSheet(`replugged://theme/${theme.path}/${theme.manifest.main}`);
-  } else if (themeSettings?.chosenPreset) {
+  } else if (themeSettings.chosenPreset) {
     el = loadStyleSheet(`replugged://theme/${theme.path}/${themeSettings.chosenPreset}`);
   } else {
     throw new Error(`Theme ${id} does not have a main variant.`);

--- a/src/types/addon.ts
+++ b/src/types/addon.ts
@@ -54,6 +54,11 @@ export const theme = common.extend({
   type: z.literal("replugged-theme"),
   main: z.string().optional(),
   splash: z.string().optional(),
+  presets: z.object({
+    label: z.string(),
+    path: z.string(),
+    default: z.boolean().optional(),
+  }).array().optional(),
 });
 
 export type ThemeManifest = z.infer<typeof theme>;
@@ -86,3 +91,9 @@ export interface PluginExports {
 export type AddonSettings = {
   disabled?: string[];
 };
+
+export type ThemeSettings = AddonSettings & {
+  [x: string]: {
+    "chosenPreset"?: string;
+  };
+}

--- a/src/types/addon.ts
+++ b/src/types/addon.ts
@@ -54,11 +54,14 @@ export const theme = common.extend({
   type: z.literal("replugged-theme"),
   main: z.string().optional(),
   splash: z.string().optional(),
-  presets: z.object({
-    label: z.string(),
-    path: z.string(),
-    default: z.boolean().optional(),
-  }).array().optional(),
+  presets: z
+    .object({
+      label: z.string(),
+      path: z.string(),
+      default: z.boolean().optional(),
+    })
+    .array()
+    .optional(),
 });
 
 export type ThemeManifest = z.infer<typeof theme>;
@@ -94,6 +97,6 @@ export type AddonSettings = {
 
 export type ThemeSettings = AddonSettings & {
   [x: string]: {
-    "chosenPreset"?: string;
+    chosenPreset?: string;
   };
-}
+};


### PR DESCRIPTION
Adds theme presets.

I've tested with a modification of the [Catppuccin](https://github.com/qwerty-mods/Catppuccin) theme. 

Presets are specified in the manifest
```json
{
    ...
    "presets": [
        {
            "label": "flavorname",
            "path": "relative/path/to/flavor",
            "default": false
        }
    ]
}
```