### PR TITLE
SliderItem margin fix and types

### DIFF
--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -13,7 +13,6 @@ const SETTINGS_DIR = CONFIG_PATHS.settings;
 
 export function getSettingsPath(namespace: string): string {
   const resolved = resolve(SETTINGS_DIR, `${namespace}.json`);
-  console.log(resolved, SETTINGS_DIR, resolved.startsWith(SETTINGS_DIR));
   if (!resolved.startsWith(`${SETTINGS_DIR}${sep}`)) {
     // Ensure file changes are restricted to the base path
     throw new Error("Invalid namespace");

--- a/src/main/ipc/themes.ts
+++ b/src/main/ipc/themes.ts
@@ -22,7 +22,7 @@ async function getTheme(path: string): Promise<RepluggedTheme> {
   const manifestPath = join(THEMES_DIR, path, "manifest.json");
   if (!manifestPath.startsWith(`${THEMES_DIR}${sep}`)) {
     // Ensure file changes are restricted to the base path
-    throw new Error("Invalid plugin name");
+    throw new Error("Invalid theme name");
   }
 
   const manifest: unknown = JSON.parse(

--- a/src/renderer/modules/common/channels.ts
+++ b/src/renderer/modules/common/channels.ts
@@ -21,6 +21,7 @@ export interface ChannelStore {
   getAllThreadsForParent(channelId: string): Channel[];
   getBasicChannel(channelId: string): Channel | undefined;
   getChannel(channelId: string): Channel | undefined;
+  getChannelIds(guildId?: string): string[];
   getDMFromUserId(userId: string): string | undefined;
   getDMUserIds(): string[];
   getGuildChannelsVersion(guildId: string): number;

--- a/src/renderer/modules/common/constants.ts
+++ b/src/renderer/modules/common/constants.ts
@@ -52,7 +52,7 @@ export const GuildFeatures = getExportsForProps<Record<string, string>>(Constant
   "VERIFIED",
   "ANIMATED_BANNER",
 ])!;
-export const MessageFlags = getExportsForProps<Record<string, string | number>>(Constants, [
+export const MessageFlags = getExportsForProps<Record<string, number>>(Constants, [
   "EPHEMERAL",
   "LOADING",
 ])!;

--- a/src/renderer/modules/common/constants.ts
+++ b/src/renderer/modules/common/constants.ts
@@ -1,6 +1,8 @@
 import { virtualMerge } from "src/renderer/util";
 import { filters, getExportsForProps, waitForModule, waitForProps } from "../webpack";
 
+type StringConcat = (...rest: string[]) => string;
+
 const ConstantsCommon = await waitForModule<Record<string, unknown>>(filters.bySource("BASE_URL:"));
 const Constants = await waitForModule<Record<string, unknown>>(filters.bySource("USER_PROFILE:"));
 export const raw = virtualMerge(ConstantsCommon, Constants);
@@ -42,7 +44,7 @@ export const ChannelTypes = getExportsForProps<Record<string, string | number>>(
   "DM",
   "GUILD_FORUM",
 ])!;
-export const Endpoints = getExportsForProps<Record<string, unknown>>(Constants, [
+export const Endpoints = getExportsForProps<Record<string, string | StringConcat>>(Constants, [
   "USERS",
   "INTEGRATIONS",
 ])!;
@@ -50,12 +52,15 @@ export const GuildFeatures = getExportsForProps<Record<string, string>>(Constant
   "VERIFIED",
   "ANIMATED_BANNER",
 ])!;
-export const MessageFlags = getExportsForProps<Record<string, number>>(Constants, [
+export const MessageFlags = getExportsForProps<Record<string, string | number>>(Constants, [
   "EPHEMERAL",
   "LOADING",
 ])!;
-export const Routes = getExportsForProps<Record<string, unknown>>(Constants, ["INDEX", "LOGIN"])!;
-export const UserFlags = getExportsForProps<Record<string, number>>(Constants, [
+export const Routes = getExportsForProps<Record<string, StringConcat>>(Constants, [
+  "INDEX",
+  "LOGIN",
+])!;
+export const UserFlags = getExportsForProps<Record<string, string | number>>(Constants, [
   "STAFF",
   "SPAMMER",
 ])!;

--- a/src/renderer/modules/common/constants.ts
+++ b/src/renderer/modules/common/constants.ts
@@ -56,7 +56,7 @@ export const MessageFlags = getExportsForProps<Record<string, number>>(Constants
   "EPHEMERAL",
   "LOADING",
 ])!;
-export const Routes = getExportsForProps<Record<string, StringConcat>>(Constants, [
+export const Routes = getExportsForProps<Record<string, string | StringConcat>>(Constants, [
   "INDEX",
   "LOGIN",
 ])!;

--- a/src/renderer/modules/common/flux.ts
+++ b/src/renderer/modules/common/flux.ts
@@ -9,9 +9,9 @@ interface Action {
   type: ActionType;
 }
 
-type ActionHandler<A extends Action = any> = (action: A) => void;
+export type ActionHandler<A extends Action = any> = (action: A) => boolean | void;
 
-type ActionHandlerRecord = {
+export type ActionHandlerRecord = {
   [A in ActionType]: ActionHandler<{ type: A; [key: string]: any }>;
 };
 
@@ -43,7 +43,7 @@ export declare class Emitter {
 
 type Callback = () => void;
 
-declare class Callbacks {
+declare class ChangeListeners {
   public listeners: Set<Callback>;
   public add(listener: Callback): void;
   public remove(listener: Callback): void;
@@ -55,7 +55,11 @@ declare class Callbacks {
 }
 
 export declare class Store {
-  public constructor(dispatcher: Dispatcher, actions?: ActionHandlerRecord, band?: DispatchBand);
+  public constructor(
+    dispatcher: Dispatcher,
+    actionHandler?: ActionHandlerRecord,
+    band?: DispatchBand,
+  );
 
   public static destroy(): void;
   public static getAll(): Store[];
@@ -65,8 +69,8 @@ export declare class Store {
   public _isInitialized: boolean;
   public _dispatchToken: DispatchToken;
   public _dispatcher: Dispatcher;
-  public _changeCallbacks: Callbacks;
-  public _reactChangeCallbacks: Callbacks;
+  public _changeCallbacks: ChangeListeners;
+  public _reactChangeCallbacks: ChangeListeners;
   public _mustEmitChanges: Parameters<Store["mustEmitChanges"]>[0];
 
   public initialize(): void;
@@ -75,8 +79,8 @@ export declare class Store {
   public getName(): string;
 
   public emitChange(): void;
-  public mustEmitChanges(func?: (action?: Action) => boolean): void;
-  public syncWith(stores: Store[], func: () => boolean, timeout?: number): void;
+  public mustEmitChanges<A extends Action>(actionHandler?: ActionHandler<A>): void;
+  public syncWith(stores: Store[], callback: () => boolean, timeout?: number): void;
   public waitFor(...stores: Store[]): void;
 
   public addChangeListener(listener: Callback): void;
@@ -85,7 +89,7 @@ export declare class Store {
   public removeChangeListener(listener: Callback): void;
   public removeReactChangeListener(listener: Callback): void;
 
-  public registerActionHandlers(actions: ActionHandlerRecord, band?: DispatchBand): void;
+  public registerActionHandlers(actionHandlers: ActionHandlerRecord, band?: DispatchBand): void;
 
   // eslint-disable-next-line @typescript-eslint/naming-convention
   public __getLocalVars?(): Record<string, unknown>;
@@ -175,7 +179,7 @@ export declare class SnapshotStore<Data = Record<string, unknown>> extends Store
   public clear: () => void;
   public getClass: () => any;
   public readSnapshot: (version: number) => Snapshot<Data>["data"] | null;
-  public registerActionHandlers: (actions: ActionHandlerRecord) => void;
+  public registerActionHandlers: (actionHandlers: ActionHandlerRecord) => void;
   public save: () => void;
 }
 

--- a/src/renderer/modules/common/fluxDispatcher.ts
+++ b/src/renderer/modules/common/fluxDispatcher.ts
@@ -1,5 +1,7 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import type EventEmitter from "events";
 import { waitForProps } from "../webpack";
+import type { ActionHandler, ActionHandlerRecord } from "./flux";
 
 export enum DispatchBand {
   Early,
@@ -7,11 +9,9 @@ export enum DispatchBand {
   Default,
 }
 
-type FluxCallback = (action?: { [index: string]: unknown }) => void;
-
 interface Action {
   type: string;
-  [index: string]: unknown;
+  [key: string]: any;
 }
 
 type ActionMetric = [string, string, number];
@@ -57,7 +57,7 @@ declare class ActionLog {
 }
 
 interface NodeData {
-  actionHandler: Record<string, FluxCallback>;
+  actionHandler: ActionHandlerRecord;
   band: DispatchBand;
   name: string;
   storeDidChange: (action: Action) => void;
@@ -86,12 +86,12 @@ export declare class DepGraph {
 }
 
 interface Handler {
-  actionHandler: FluxCallback;
+  actionHandler: ActionHandler;
   name: string;
   storeDidChange: (action: Action) => void;
 }
 
-declare class ActionHandlers {
+declare class ActionHandlersGraph {
   public _orderedActionHandlers: Record<string, Handler[]>;
   public _orderedCallbackTokens: string[];
   public _lastID: number;
@@ -102,7 +102,7 @@ declare class ActionHandlers {
   public getOrderedActionHandlers: (action: Action) => Handler[];
   public register: (
     name: string,
-    actionHandler: Record<string, FluxCallback>,
+    actionHandlers: ActionHandlerRecord,
     storeDidChange: (action: Action) => void,
     band: DispatchBand,
     token?: string,
@@ -117,12 +117,12 @@ declare class ActionHandlers {
 }
 
 export interface FluxDispatcher {
-  _actionHandlers: ActionHandlers;
+  _actionHandlers: ActionHandlersGraph;
   _currentDispatchActionType: string | null;
   _defaultBand: DispatchBand;
   _interceptors: Array<(...rest: unknown[]) => unknown>;
   _processingWaitQueue: boolean;
-  _subscriptions: Record<string, Set<FluxCallback>>;
+  _subscriptions: Record<string, Set<ActionHandler>>;
   _waitQueue: Array<(...rest: unknown[]) => unknown>;
   actionLogger: ActionLogger;
 
@@ -139,12 +139,12 @@ export interface FluxDispatcher {
   dispatch: (action: Action) => void;
   flushWaitQueue: () => void;
   isDispatching: () => boolean;
-  subscribe: (type: string, callback: FluxCallback) => void;
-  unsubscribe: (type: string, callback: FluxCallback) => void;
+  subscribe: <A extends Action>(type: string, callback: ActionHandler<A>) => void;
+  unsubscribe: <A extends Action>(type: string, callback: ActionHandler<A>) => void;
   wait: (callback: (...rest: unknown[]) => unknown) => void;
   register: (
     name: string,
-    actionHandler: Record<string, FluxCallback>,
+    actionHandlers: ActionHandlerRecord,
     storeDidChange: (action: Action) => void,
     band: DispatchBand,
     token?: string,

--- a/src/renderer/modules/common/messages.ts
+++ b/src/renderer/modules/common/messages.ts
@@ -371,6 +371,12 @@ export interface MessageActions {
   ) => Promise<unknown | void>;
   sendBotMessage: (channelId: string, content: string, messageName?: string) => void;
   sendClydeError: (channelId: string, code?: number) => void;
+  sendClydeProfileOverride: (
+    channelId: string,
+    clydeProfileURL: string,
+    analyticsTriggeredFrom?: string,
+    suggestedInvite?: InviteSuggestion,
+  ) => Promise<unknown | void>;
   sendGreetMessage: (
     channelId: string,
     stickerId: string,

--- a/src/renderer/modules/components/FormItem.tsx
+++ b/src/renderer/modules/components/FormItem.tsx
@@ -40,25 +40,22 @@ export type FormItemType = React.FC<FormItemProps>;
 
 export default ((props) => {
   const { note, notePosition = "before", noteStyle, noteClassName, divider, ...compProps } = props;
+
+  const noteStyleDefault = notePosition === "before" ? { marginTop: 8 } : { marginTop: 8 };
+  const noteComp = (
+    <FormText.DESCRIPTION
+      disabled={props.disabled}
+      className={noteClassName}
+      style={{ ...noteStyleDefault, ...noteStyle }}>
+      {note}
+    </FormText.DESCRIPTION>
+  );
+
   return (
     <FormItemComp {...compProps}>
-      {note && notePosition === "before" && (
-        <FormText.DESCRIPTION
-          disabled={props.disabled}
-          className={noteClassName}
-          style={{ marginBottom: 8, ...noteStyle }}>
-          {note}
-        </FormText.DESCRIPTION>
-      )}
+      {note && notePosition === "before" && noteComp}
       {props.children}
-      {note && notePosition === "after" && (
-        <FormText.DESCRIPTION
-          disabled={props.disabled}
-          className={noteClassName}
-          style={{ marginTop: 8, ...noteStyle }}>
-          {note}
-        </FormText.DESCRIPTION>
-      )}
+      {note && notePosition === "after" && noteComp}
       {divider && <Divider className={classes.dividerDefault} />}
     </FormItemComp>
   );

--- a/src/renderer/modules/components/FormItem.tsx
+++ b/src/renderer/modules/components/FormItem.tsx
@@ -41,7 +41,7 @@ export type FormItemType = React.FC<FormItemProps>;
 export default ((props) => {
   const { note, notePosition = "before", noteStyle, noteClassName, divider, ...compProps } = props;
 
-  const noteStyleDefault = notePosition === "before" ? { marginTop: 8 } : { marginTop: 8 };
+  const noteStyleDefault = notePosition === "before" ? { marginBottom: 8 } : { marginTop: 8 };
   const noteComp = (
     <FormText.DESCRIPTION
       disabled={props.disabled}

--- a/src/renderer/modules/components/Loader.tsx
+++ b/src/renderer/modules/components/Loader.tsx
@@ -6,6 +6,7 @@ const Types = {
   CHASING_DOTS: "chasingDots",
   PULSING_ELLIPSIS: "pulsingEllipsis",
   SPINNING_CIRCLE: "spinningCircle",
+  SPINNING_CIRCLE_SIMPLE: "spinningCircleSimple",
   LOW_MOTION: "lowMotion",
 } as const;
 
@@ -20,7 +21,7 @@ type LoaderProps = GenericLoaderProps & {
   type?: (typeof Types)[keyof typeof Types];
 } & React.ComponentPropsWithoutRef<"span">;
 type SpinningCircleLoaderProps = GenericLoaderProps & {
-  type?: (typeof Types)["SPINNING_CIRCLE"];
+  type?: (typeof Types)["SPINNING_CIRCLE"] | (typeof Types)["SPINNING_CIRCLE_SIMPLE"];
 } & React.ComponentPropsWithoutRef<"div">;
 
 export type LoaderType = React.FC<LoaderProps | SpinningCircleLoaderProps> & {

--- a/src/renderer/modules/components/Modal.tsx
+++ b/src/renderer/modules/components/Modal.tsx
@@ -17,6 +17,7 @@ interface ModalRootProps extends Omit<React.ComponentPropsWithoutRef<"div">, "ch
   fullscreenOnMobile?: boolean;
   hideShadow?: boolean;
   onAnimationEnd?(): string;
+  returnRef?: React.Ref<unknown>;
 }
 
 interface ModalHeaderProps {

--- a/src/renderer/modules/components/RadioItem.tsx
+++ b/src/renderer/modules/components/RadioItem.tsx
@@ -16,8 +16,7 @@ type RadioOptionType = {
   collapsibleContent?: React.ReactNode;
 };
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-type RadioProps = {
+interface RadioProps {
   options: RadioOptionType[];
   value?: string;
   onChange: (option: RadioOptionType) => void;
@@ -32,7 +31,7 @@ type RadioProps = {
   itemTitleClassName?: string;
   radioItemClassName?: string;
   collapsibleClassName?: string;
-};
+}
 
 export type RadioType = React.FC<RadioProps> & {
   Sizes: Record<"NOT_SET" | "NONE" | "SMALL" | "MEDIUM", string>;

--- a/src/renderer/modules/components/SliderItem.tsx
+++ b/src/renderer/modules/components/SliderItem.tsx
@@ -1,6 +1,6 @@
 import type React from "react";
 import { FormItem } from ".";
-import { filters, waitForModule } from "../webpack";
+import { filters, waitForModule, waitForProps } from "../webpack";
 
 const MarkerPositions = {
   ABOVE: 0,
@@ -61,6 +61,8 @@ export const Slider = ((props) => {
 }) as SliderType;
 Slider.MarkerPositions = MarkerPositions;
 
+const classes = await waitForProps<Record<"marginTop20", string>>("marginTop20");
+
 interface SliderItemProps extends SliderProps {
   note?: string;
   style?: React.CSSProperties;
@@ -69,7 +71,7 @@ interface SliderItemProps extends SliderProps {
 export type SliderItemType = React.FC<React.PropsWithChildren<SliderItemProps>>;
 
 export const SliderItem = (props: React.PropsWithChildren<SliderItemProps>): React.ReactElement => {
-  const { children, ...compProps } = props;
+  const { children, className, ...compProps } = props;
   return (
     <FormItem
       title={children}
@@ -78,7 +80,12 @@ export const SliderItem = (props: React.PropsWithChildren<SliderItemProps>): Rea
       noteStyle={{ marginBottom: props.markers ? 16 : 4 }}
       disabled={props.disabled}
       divider>
-      <Slider {...compProps} />
+      <Slider
+        className={`${props.markers && !props.note ? classes.marginTop20 : ""}${
+          className ? ` ${className}` : ""
+        }`}
+        {...compProps}
+      />
     </FormItem>
   );
 };


### PR DESCRIPTION
- Fixed SliderItem's margin when there are markers w/o a note.
Before -> After

![image](https://github.com/replugged-org/replugged/assets/38290480/2c7f4197-18c1-4f8b-8a48-2e041d782ad1)
![image](https://github.com/replugged-org/replugged/assets/38290480/3b5a89f2-e703-4a17-8c2a-67eec5742520)
- Updated types for `channels`, `constants` (Endpoints and Routes can be a function), `flux` (more precise and with generics), `fluxDispatcher` (more precise and with generics), `messages`, `Loader` (new enum).
- Fixed the word plugin being used for themes after the security patch.
- Removed a leftover console log.