### PR TITLE
Add esbuild overwrites

### DIFF
--- a/bin/index.mts
+++ b/bin/index.mts
@@ -12,6 +12,7 @@ import {
   rmSync,
   writeFileSync,
 } from "fs";
+import {cwd} from "process";
 import esbuild from "esbuild";
 import path from "path";
 import updateNotifier from "update-notifier";
@@ -40,12 +41,15 @@ export const directory = process.cwd();
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageJson = JSON.parse(readFileSync(path.resolve(dirname, "package.json"), "utf-8"));
 let extraESBuildConfig = new Promise<(current: esbuild.BuildOptions) => esbuild.BuildOptions>(
-  () => (v: esbuild.BuildOptions) => v,
+  (resolve) => resolve(v => v)
 );
 
 if (existsSync("./esbuild.extra.mjs")) {
-  // @ts-expect-error it doesn't exist here, but it does exist in the pkg
-  extraESBuildConfig = import("./esbuild.extra.mjs");
+  extraESBuildConfig = new Promise((resolve) => {
+    import(path.join(cwd(), "esbuild.extra.mjs")).then(v => {
+      resolve(v.default)
+    })
+  });
 }
 
 const updateMessage = `Update available ${chalk.dim("{currentVersion}")}${chalk.reset(

--- a/bin/index.mts
+++ b/bin/index.mts
@@ -12,7 +12,7 @@ import {
   rmSync,
   writeFileSync,
 } from "fs";
-import {cwd} from "process";
+import { cwd } from "process";
 import esbuild from "esbuild";
 import path from "path";
 import updateNotifier from "update-notifier";
@@ -41,14 +41,14 @@ export const directory = process.cwd();
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageJson = JSON.parse(readFileSync(path.resolve(dirname, "package.json"), "utf-8"));
 let extraESBuildConfig = new Promise<(current: esbuild.BuildOptions) => esbuild.BuildOptions>(
-  (resolve) => resolve(v => v)
+  (resolve) => resolve((v) => v),
 );
 
 if (existsSync("./esbuild.extra.mjs")) {
   extraESBuildConfig = new Promise((resolve) => {
-    import(path.join(cwd(), "esbuild.extra.mjs")).then(v => {
-      resolve(v.default)
-    })
+    import(path.join(cwd(), "esbuild.extra.mjs")).then((v) => {
+      resolve(v.default);
+    });
   });
 }
 

--- a/bin/index.mts
+++ b/bin/index.mts
@@ -39,11 +39,13 @@ export const directory = process.cwd();
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageJson = JSON.parse(readFileSync(path.resolve(dirname, "package.json"), "utf-8"));
-let extraESBuildConfig = new Promise<(current: esbuild.BuildOptions) => esbuild.BuildOptions>(() => ((v: esbuild.BuildOptions) => v))
+let extraESBuildConfig = new Promise<(current: esbuild.BuildOptions) => esbuild.BuildOptions>(
+  () => (v: esbuild.BuildOptions) => v,
+);
 
 if (existsSync("./esbuild.extra.mjs")) {
   // @ts-expect-error it doesn't exist here, but it does exist in the pkg
-  extraESBuildConfig = import("./esbuild.extra.mjs")
+  extraESBuildConfig = import("./esbuild.extra.mjs");
 }
 
 const updateMessage = `Update available ${chalk.dim("{currentVersion}")}${chalk.reset(
@@ -388,15 +390,17 @@ async function buildPlugin({ watch, noInstall, production, noReload, addon }: Ar
 
   const targets: Array<Promise<esbuild.BuildContext>> = [];
 
-  const overwrites = await extraESBuildConfig
+  const overwrites = await extraESBuildConfig;
 
   if ("renderer" in manifest) {
     targets.push(
-      esbuild.context(overwrites({
-        ...common,
-        entryPoints: [path.join(folderPath, manifest.renderer)],
-        outfile: `${distPath}/renderer.js`,
-      })),
+      esbuild.context(
+        overwrites({
+          ...common,
+          entryPoints: [path.join(folderPath, manifest.renderer)],
+          outfile: `${distPath}/renderer.js`,
+        }),
+      ),
     );
 
     manifest.renderer = "renderer.js";
@@ -404,11 +408,13 @@ async function buildPlugin({ watch, noInstall, production, noReload, addon }: Ar
 
   if ("plaintextPatches" in manifest) {
     targets.push(
-      esbuild.context(overwrites({
-        ...common,
-        entryPoints: [path.join(folderPath, manifest.plaintextPatches)],
-        outfile: `${distPath}/plaintextPatches.js`,
-      })),
+      esbuild.context(
+        overwrites({
+          ...common,
+          entryPoints: [path.join(folderPath, manifest.plaintextPatches)],
+          outfile: `${distPath}/plaintextPatches.js`,
+        }),
+      ),
     );
 
     manifest.plaintextPatches = "plaintextPatches.js";
@@ -472,15 +478,17 @@ async function buildTheme({ watch, noInstall, production, noReload, addon }: Arg
 
   const targets: Array<Promise<esbuild.BuildContext>> = [];
 
-  const overwrites = await extraESBuildConfig
+  const overwrites = await extraESBuildConfig;
 
   if (main) {
     targets.push(
-      esbuild.context(overwrites({
-        ...common,
-        entryPoints: [main],
-        outfile: `${distPath}/main.css`,
-      })),
+      esbuild.context(
+        overwrites({
+          ...common,
+          entryPoints: [main],
+          outfile: `${distPath}/main.css`,
+        }),
+      ),
     );
 
     manifest.main = "main.css";
@@ -488,11 +496,13 @@ async function buildTheme({ watch, noInstall, production, noReload, addon }: Arg
 
   if (splash) {
     targets.push(
-      esbuild.context(overwrites({
-        ...common,
-        entryPoints: [splash],
-        outfile: `${distPath}/splash.css`,
-      })),
+      esbuild.context(
+        overwrites({
+          ...common,
+          entryPoints: [splash],
+          outfile: `${distPath}/splash.css`,
+        }),
+      ),
     );
 
     manifest.plaintextPatches = "splash.css";

--- a/bin/index.mts
+++ b/bin/index.mts
@@ -39,7 +39,7 @@ export const directory = process.cwd();
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageJson = JSON.parse(readFileSync(path.resolve(dirname, "package.json"), "utf-8"));
-let extraESBuildConfig = new Promise<esbuild.BuildOptions>(() => ({}))
+let extraESBuildConfig = new Promise<(current: esbuild.BuildOptions) => esbuild.BuildOptions>(() => ((v: esbuild.BuildOptions) => v))
 
 if (existsSync("./esbuild.extra.mjs")) {
   // @ts-expect-error it doesn't exist here, but it does exist in the pkg
@@ -392,12 +392,11 @@ async function buildPlugin({ watch, noInstall, production, noReload, addon }: Ar
 
   if ("renderer" in manifest) {
     targets.push(
-      esbuild.context({
+      esbuild.context(overwrites({
         ...common,
         entryPoints: [path.join(folderPath, manifest.renderer)],
         outfile: `${distPath}/renderer.js`,
-        ...overwrites,
-      }),
+      })),
     );
 
     manifest.renderer = "renderer.js";
@@ -405,12 +404,11 @@ async function buildPlugin({ watch, noInstall, production, noReload, addon }: Ar
 
   if ("plaintextPatches" in manifest) {
     targets.push(
-      esbuild.context({
+      esbuild.context(overwrites({
         ...common,
         entryPoints: [path.join(folderPath, manifest.plaintextPatches)],
         outfile: `${distPath}/plaintextPatches.js`,
-        ...overwrites,
-      }),
+      })),
     );
 
     manifest.plaintextPatches = "plaintextPatches.js";
@@ -478,12 +476,11 @@ async function buildTheme({ watch, noInstall, production, noReload, addon }: Arg
 
   if (main) {
     targets.push(
-      esbuild.context({
+      esbuild.context(overwrites({
         ...common,
         entryPoints: [main],
         outfile: `${distPath}/main.css`,
-        ...overwrites,
-      }),
+      })),
     );
 
     manifest.main = "main.css";
@@ -491,12 +488,11 @@ async function buildTheme({ watch, noInstall, production, noReload, addon }: Arg
 
   if (splash) {
     targets.push(
-      esbuild.context({
+      esbuild.context(overwrites({
         ...common,
         entryPoints: [splash],
         outfile: `${distPath}/splash.css`,
-        ...overwrites,
-      }),
+      })),
     );
 
     manifest.plaintextPatches = "splash.css";

--- a/scripts/build-bin.mts
+++ b/scripts/build-bin.mts
@@ -21,7 +21,7 @@ const context = await esbuild.context({
   platform: "node",
   target: `node${NODE_VERSION}`,
   outfile: "bin.mjs",
-  external: packageNames,
+  external: [...packageNames, "./esbuild.extra.mjs"],
 });
 
 await context.rebuild();

--- a/scripts/build-bin.mts
+++ b/scripts/build-bin.mts
@@ -21,7 +21,7 @@ const context = await esbuild.context({
   platform: "node",
   target: `node${NODE_VERSION}`,
   outfile: "bin.mjs",
-  external: [...packageNames, "./esbuild.extra.mjs"],
+  external: packageNames,
 });
 
 await context.rebuild();


### PR DESCRIPTION
This PR adds the ability for plugin & theme developers to overwrite the replugged esbuild config. 
This is especially useful for when plugin developers need special configurations for their plugin to build - eg. adding font loaders for their css files. 

The reason its a function rather than just extra config values is to allow developers to write their own plugins without removing the current required plugins.

The reason I chose to name the extra config file `esbuild.extra.mjs` is to avoid editors like vscode from using interpreting a `esbuild.(m)js` file as the thing to use for building (it causes a lang server crash)

This only affects plugin developers - this does not need a new replugged version release, just a new npm package.