### PR TITLE
change the tryPort to use hostname.local (for wsl to work)

### DIFF
--- a/bin/index.mts
+++ b/bin/index.mts
@@ -24,6 +24,7 @@ import { logBuildPlugin } from "../src/util.mjs";
 import { sassPlugin } from "esbuild-sass-plugin";
 import { fileURLToPath } from "url";
 import { AddonType, getAddonFolder, isMonoRepo, selectAddon } from "./mono.mjs";
+import { hostname } from "os";
 
 interface BaseArgs {
   watch?: boolean;
@@ -70,7 +71,7 @@ let connectingPromise: Promise<WebSocket | undefined> | undefined;
  * Try to connect to RPC on a specific port and handle the READY event as well as errors and close events
  */
 function tryPort(port: number): Promise<WebSocket | undefined> {
-  ws = new WebSocket(`ws://127.0.0.1:${port}/?v=1&client_id=REPLUGGED-${random()}`);
+  ws = new WebSocket(`ws://${hostname()}.local:${port}/?v=1&client_id=REPLUGGED-${random()}`);
   return new Promise((resolve, reject) => {
     let didFinish = false;
     ws?.on("message", (data) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true


### PR DESCRIPTION
when you try to use the --watch flag in wsl, it cannot connect since the networks are *technically* separated. if you use hostname.local however, the wsl "container" can connect to the main windows machine.

this should not break any other systems since i tested it in linux, linux in wsl and on windows without issue