### PR TITLE
fix webpack

### DIFF
--- a/src/renderer/modules/webpack/patch-load.ts
+++ b/src/renderer/modules/webpack/patch-load.ts
@@ -71,13 +71,13 @@ function patchChunk(chunk: WebpackChunk): void {
  * @internal
  */
 function patchPush(webpackChunk: WebpackChunkGlobal): void {
-  function handlePush(original: WebpackChunkGlobal["push"], chunk: WebpackChunk): unknown {
+  const original = webpackChunk.push.bind(webpackChunk);
+  function handlePush(chunk: WebpackChunk): unknown {
     patchChunk(chunk);
     return original(chunk);
   }
 
-  // mirror behavior of discord's redefinitions of webpackChunk.push to not break things
-  webpackChunk.push = handlePush.bind(null, webpackChunk.push.bind(webpackChunk));
+  webpackChunk.push = handlePush as WebpackChunkGlobal["push"];
 }
 
 /**
@@ -106,7 +106,7 @@ function loadWebpackModules(chunksGlobal: WebpackChunkGlobal): void {
             });
           }
         }
-      }
+      };
     },
   ]);
 

--- a/src/types/webpack.ts
+++ b/src/types/webpack.ts
@@ -27,14 +27,17 @@ export type WebpackModule = (
   wpRequire: WebpackRequire,
 ) => void;
 
-export type WebpackChunk = [Array<symbol | number>, Record<number, WebpackModule>];
+export type WebpackChunk = [
+  Array<symbol | number>,
+  Record<number, WebpackModule>,
+  ((r: WebpackRequire) => unknown)?,
+];
 
 // Do NOT put `WebpackChunk[]` first, otherwise TS
 // prioritizes Array.prototype.push over this custom
 // push method and starts producing errors.
 export type WebpackChunkGlobal = {
-  push(chunk: WebpackChunk): void;
-  push<T extends (r: WebpackRequire) => unknown>(chunk: [...WebpackChunk, T]): ReturnType<T>;
+  push(chunk: WebpackChunk): unknown;
 } & WebpackChunk[];
 
 export type Filter = (module: RawModule) => boolean | ModuleExports;


### PR DESCRIPTION
types are broken when assigning to `webpackChunk.push` ([here](https://github.com/Penguin-Spy/replugged/blob/acffec100afe8114311f7e16deead508ad79d85f/src/renderer/modules/webpack/patch-load.ts#L80)). after a cursory glance i couldn't see how to make TS not mad. the code itself works just fine.

replugged loads, all of the common modules/components fail to be found, and some plugins do load if their webpack searches happened to not break.