### PR TITLE
Fix missing wpRequire.c

### DIFF
--- a/src/renderer/modules/webpack/patch-load.ts
+++ b/src/renderer/modules/webpack/patch-load.ts
@@ -1,4 +1,9 @@
-import type { WebpackChunk, WebpackChunkGlobal, WebpackRequire } from "../../../types";
+import type {
+  WebpackChunk,
+  WebpackChunkGlobal,
+  WebpackRawModules,
+  WebpackRequire,
+} from "../../../types";
 
 import { listeners } from "./lazy";
 
@@ -10,6 +15,7 @@ import { patchModuleSource } from "./plaintext-patch";
  * @hidden
  */
 export let wpRequire: WebpackRequire | undefined;
+export let webpackChunks: WebpackRawModules | undefined;
 
 let signalReady: () => void;
 let ready = false;
@@ -105,6 +111,7 @@ function loadWebpackModules(chunksGlobal: WebpackChunkGlobal): void {
     {},
     (r: WebpackRequire | undefined) => {
       wpRequire = r!;
+      if (wpRequire.c && !webpackChunks) webpackChunks = wpRequire.c;
 
       if (r) {
         r.d = (module: unknown, exports: Record<string, () => unknown>) => {

--- a/src/types/webpack.ts
+++ b/src/types/webpack.ts
@@ -15,8 +15,10 @@ export interface RawModule<T = unknown> {
   exports: T;
 }
 
+export type WebpackRawModules = Record<string | number, RawModule>;
+
 export type WebpackRequire = ((e: number) => unknown) & {
-  c: Record<string | number, RawModule>;
+  c?: WebpackRawModules;
   d: (module: unknown, exports: Record<string, () => unknown>) => void;
   m: WebpackChunk;
 };


### PR DESCRIPTION
For some reason, wpRequire.c is removed at some point after startup, but the chunks are still all on it, so I just save the reference to it while we still have it.