### PR TITLE
Update tsx dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "prompts": "^2.4.2",
     "semver": "^7.5.4",
     "standalone-electron-types": "^1.0.0",
-    "tsx": "^3.14.0",
+    "tsx": "^4.6.2",
     "update-notifier": "^6.0.2",
     "ws": "^8.14.2",
     "yargs": "^17.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ dependencies:
     specifier: ^1.0.0
     version: 1.0.0
   tsx:
-    specifier: ^3.14.0
-    version: 3.14.0
+    specifier: ^4.6.2
+    version: 4.6.2
   update-notifier:
     specifier: ^6.0.2
     version: 6.0.2
@@ -1807,10 +1807,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       fill-range: 7.0.1
-
-  /buffer-from@1.1.2:
-    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
-    dev: false
 
   /buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
@@ -4989,18 +4985,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /source-map-support@0.5.21:
-    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
-    dependencies:
-      buffer-from: 1.1.2
-      source-map: 0.6.1
-    dev: false
-
-  /source-map@0.6.1:
-    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
-    engines: {node: '>=0.10.0'}
-    dev: false
-
   /spdx-correct@3.2.0:
     resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
     dependencies:
@@ -5258,13 +5242,13 @@ packages:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
     dev: true
 
-  /tsx@3.14.0:
-    resolution: {integrity: sha512-xHtFaKtHxM9LOklMmJdI3BEnQq/D5F73Of2E1GDrITi9sgoVkvIsrQUTY1G8FlmGtA+awCI4EBlTRRYxkL2sRg==}
+  /tsx@4.6.2:
+    resolution: {integrity: sha512-QPpBdJo+ZDtqZgAnq86iY/PD2KYCUPSUGIunHdGwyII99GKH+f3z3FZ8XNFLSGQIA4I365ui8wnQpl8OKLqcsg==}
+    engines: {node: '>=18.0.0'}
     hasBin: true
     dependencies:
       esbuild: 0.18.20
       get-tsconfig: 4.7.2
-      source-map-support: 0.5.21
     optionalDependencies:
       fsevents: 2.3.3
     dev: false


### PR DESCRIPTION
This updates the tsx release to the latest major version. Between v3 & v4, the breaking changes are described as:

- Rename env vars prefix from ESBK_ to TSX_
- only Node.js LTS versions v18 and up are now supported

([Source](https://github.com/privatenumber/tsx/releases/tag/v4.0.0))

We clear both conditions already.

The main reason to upgrade is [this bugfix](https://github.com/privatenumber/tsx/pull/422). With this fix, I am hoping that [plugins will be able to be built again](https://github.com/ShadiestGoat/Replugged-Latex/actions/runs/7175831209/job/19539775141)