### PR TITLE
fix: crash after opening settings and late ignition

### DIFF
--- a/src/renderer/coremods/settings/index.tsx
+++ b/src/renderer/coremods/settings/index.tsx
@@ -1,8 +1,6 @@
 import { Messages } from "@common/i18n";
 import { Text } from "@components";
 import { Injector } from "@replugged";
-import { filters, waitForModule } from "src/renderer/modules/webpack";
-import type { Section as SectionType } from "src/types/coremods/settings";
 import { Divider, Header, Section, insertSections, settingsTools } from "./lib";
 import { General, Plugins, QuickCSS, Themes, Updater } from "./pages";
 
@@ -10,28 +8,15 @@ const injector = new Injector();
 
 export { insertSections };
 
-interface VersionMod {
-  default: () => React.ReactElement;
-}
-async function injectVersionInfo(): Promise<void> {
-  const mod = await waitForModule<VersionMod>(filters.bySource(".versionHash"), { raw: true });
-
-  injector.after(mod.exports, "default", (_, res) => {
-    res.props.children.push(
-      <Text
-        variant="text-xs/normal"
-        color="text-muted"
-        tag="span"
-        style={{ textTransform: "none" }}>
-        {Messages.REPLUGGED_VERSION.format({ version: window.RepluggedNative.getVersion() })}
-      </Text>,
-    );
-  });
+export function VersionInfo(): React.ReactElement {
+  return (
+    <Text variant="text-xs/normal" color="text-muted" tag="span" style={{ textTransform: "none" }}>
+      {Messages.REPLUGGED_VERSION.format({ version: window.RepluggedNative.getVersion() })}
+    </Text>
+  );
 }
 
-export async function start(): Promise<void> {
-  void injectVersionInfo();
-
+export function start(): void {
   settingsTools.addAfter("Billing", [
     Divider(),
     Header("Replugged"),
@@ -61,17 +46,6 @@ export async function start(): Promise<void> {
       elem: Updater,
     }),
   ]);
-
-  const mod = await waitForModule<{
-    default: {
-      prototype: {
-        getPredicateSections: (_: unknown) => SectionType[];
-      };
-    };
-  }>(filters.bySource("getPredicateSections"));
-  injector.after(mod.default.prototype, "getPredicateSections", (_, res) => {
-    return insertSections(res);
-  });
 }
 
 export function stop(): void {

--- a/src/renderer/coremods/settings/plaintextPatches.ts
+++ b/src/renderer/coremods/settings/plaintextPatches.ts
@@ -1,0 +1,25 @@
+import type { PlaintextPatch } from "src/types";
+
+const coremodStr = "replugged.coremods.coremods.settings";
+
+export default [
+  {
+    find: "getPredicateSections",
+    replacements: [
+      {
+        match: /this\.props\.sections\.filter\((.+?)\)}/,
+        replace: (_, sections) =>
+          `${coremodStr}.insertSections(this.props.sections.filter(${sections}))};`,
+      },
+    ],
+  },
+  {
+    find: ".versionHash",
+    replacements: [
+      {
+        match: /appArch,children:.{0,200}?className:\w+\.line,.{0,100}children:\w+}\):null/,
+        replace: `$&,${coremodStr}.VersionInfo()`,
+      },
+    ],
+  },
+] as PlaintextPatch[];

--- a/src/renderer/managers/coremods.ts
+++ b/src/renderer/managers/coremods.ts
@@ -9,6 +9,7 @@ import { default as notices } from "../coremods/notices/plaintextPatches";
 import { default as contextMenu } from "../coremods/contextMenu/plaintextPatches";
 import { default as languagePlaintext } from "../coremods/language/plaintextPatches";
 import { default as commandsPlaintext } from "../coremods/commands/plaintextPatches";
+import { default as settingsPlaintext } from "../coremods/settings/plaintextPatches";
 import { Logger } from "../modules/logger";
 
 const logger = Logger.api("Coremods");
@@ -85,6 +86,7 @@ export function runPlaintextPatches(): Promise<void> {
       contextMenu,
       languagePlaintext,
       commandsPlaintext,
+      settingsPlaintext,
     ].forEach(patchPlaintext);
     res();
   });


### PR DESCRIPTION
Fixes client crashing after opening the user settings (Discord added copiable version info). Moved back to a plaintext patch, just like in v4.7.0, fixing the delayed ignition, consequently various features of the mod that did not start immediately (updater and quick css).