### PR TITLE
fix: missing key for the i18n contribute string

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-export const DISCORD_INVITE = "https://discord.gg/HnYFUhv4x4";
+export const DISCORD_INVITE = "HnYFUhv4x4";
 export const WEBLATE_URL = "https://i18n.replugged.dev";
 export const WEBSITE_URL = "https://replugged.dev";
 export const BETA_WEBSITE_URL = "https://beta.replugged.dev";

--- a/src/renderer/coremods/badges/index.tsx
+++ b/src/renderer/coremods/badges/index.tsx
@@ -58,13 +58,14 @@ const cache = new Map<string, BadgeCache>();
 const REFRESH_INTERVAL = 1000 * 60 * 30;
 
 const contributorsUrl = `${generalSettings.get("apiUrl")}/contributors`;
+const inviteUrl = `https://discord.gg/${DISCORD_INVITE}`;
 
 const badgeElements = [
   {
     id: "booster",
     description: Messages.REPLUGGED_BADGES_BOOSTER,
     component: Badges.Booster,
-    link: DISCORD_INVITE,
+    link: inviteUrl,
   },
   {
     id: "contributor",
@@ -84,13 +85,13 @@ const badgeElements = [
     id: "staff",
     description: Messages.REPLUGGED_BADGES_STAFF,
     component: Badges.Staff,
-    link: DISCORD_INVITE,
+    link: inviteUrl,
   },
   {
     id: "support",
     description: Messages.REPLUGGED_BADGES_SUPPORT,
     component: Badges.Support,
-    link: DISCORD_INVITE,
+    link: inviteUrl,
   },
   {
     id: "translator",

--- a/src/renderer/coremods/language/index.tsx
+++ b/src/renderer/coremods/language/index.tsx
@@ -13,7 +13,7 @@ export function Card(): React.ReactElement {
   return (
     <FormNotice
       title={Messages.REPLUGGED_I18N}
-      body={Messages.REPLUGGED_I18N_CONTRIBUTE.format({ WEBLATE_URL })}
+      body={Messages.REPLUGGED_I18N_CONTRIBUTE.format({ weblateUrl: WEBLATE_URL })}
       type={FormNotice.Types.PRIMARY}
       style={{ marginBottom: 20 }}
     />

--- a/src/renderer/coremods/welcome/index.ts
+++ b/src/renderer/coremods/welcome/index.ts
@@ -1,6 +1,7 @@
 import { generalSettings } from "../settings/pages/General";
 import { notices, util } from "@replugged";
 import { Messages } from "@common/i18n";
+import { DISCORD_INVITE } from "src/constants";
 
 export function start(): void {
   if (!generalSettings.get("showWelcomeNoticeOnOpen")) return;
@@ -9,7 +10,7 @@ export function start(): void {
     button: {
       text: Messages.REPLUGGED_NOTICES_JOIN_SERVER_BUTTON,
       onClick: () => {
-        void util.goToOrJoinServer("HnYFUhv4x4");
+        void util.goToOrJoinServer(DISCORD_INVITE);
         generalSettings.set("showWelcomeNoticeOnOpen", false);
       },
     },


### PR DESCRIPTION
Add back the key for the i18n contribute string used in the language settings.
I also modified the invite server constant so that it can be used in the welcome notice.