### PR TITLE
fix(scripts): catch and exit if building fails

### DIFF
--- a/bin/index.mts
+++ b/bin/index.mts
@@ -272,7 +272,7 @@ async function handleContexts(
       if (watch) {
         await context.watch();
       } else {
-        await context.rebuild().catch(() => {});
+        await context.rebuild().catch(() => process.exit(1));
         context.dispose();
       }
     }),
@@ -364,7 +364,9 @@ async function buildPlugin({ watch, noInstall, production, noReload, addon }: Ar
   const install: esbuild.Plugin = {
     name: "install",
     setup: (build) => {
-      build.onEnd(async () => {
+      build.onEnd(async (result) => {
+        if (result.errors.length > 0) return;
+
         if (!noInstall) {
           const dest = path.join(CONFIG_PATH, "plugins", manifest.id);
           if (existsSync(dest)) rmSync(dest, { recursive: true, force: true });
@@ -452,7 +454,9 @@ async function buildTheme({ watch, noInstall, production, noReload, addon }: Arg
   const install: esbuild.Plugin = {
     name: "install",
     setup: (build) => {
-      build.onEnd(async () => {
+      build.onEnd(async (result) => {
+        if (result.errors.length > 0) return;
+
         if (!noInstall) {
           const dest = path.join(CONFIG_PATH, "themes", manifest.id);
           if (existsSync(dest)) rmSync(dest, { recursive: true, force: true });

--- a/scripts/build.mts
+++ b/scripts/build.mts
@@ -33,7 +33,9 @@ rmSync("replugged.asar", { force: true });
 const preBundle: esbuild.Plugin = {
   name: "preBundle",
   setup: (build) => {
-    build.onEnd(() => {
+    build.onEnd((result) => {
+      if (result.errors.length > 0) return;
+
       if (!existsSync(`${distDir}/i18n`)) {
         mkdirSync(`${distDir}/i18n`);
       }
@@ -114,7 +116,7 @@ await Promise.all(
     if (watch) {
       await context.watch();
     } else {
-      await context.rebuild().catch(() => {});
+      await context.rebuild().catch(() => process.exit(1));
       context.dispose();
     }
   }),


### PR DESCRIPTION
Previously it would have printed an error in the console but would have continued anyway saying that the building process went ok. With this PR instead if an error is caught by the building then we exit immeditately with a failure code 1. In this way the jobs of a workflow on GitHub also fail if something goes wrong.

https://discord.com/channels/1000926524452647132/1000955967627874424/1254504021570486302
The job would have ended successfully even if the building had not gone well, making the developer believe that the addon was ready.

Tested with various cases, even with watch.