### PR TITLE
Fix crashes

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -62,7 +62,8 @@
     "Vendicated",
     "webauthn",
     "weblate",
-    "Withs"
+    "Withs",
+    "YofukashiNo"
   ],
   "ignoreWords": [],
   "import": [],

--- a/src/renderer/coremods/language/plaintextPatches.ts
+++ b/src/renderer/coremods/language/plaintextPatches.ts
@@ -8,11 +8,12 @@ export default [
     replacements: [
       {
         match: /(\.Messages\.LANGUAGE,)\s*children:((?:[^}]*?}){3}\))/,
-        replace: (_, prefix, ogChild) => `${prefix}children:[${coremodStr}.Card(),${ogChild}]`,
+        replace: (_, prefix, ogChild) =>
+          `${prefix}children:[${coremodStr}?.Card() ?? null,${ogChild}]`,
       },
       {
         match: /children:\[(.+?\.localeName[^\]]*?)]/,
-        replace: (_, ogChild) => `children:[${coremodStr}.Percentage(${ogChild})]`,
+        replace: (_, ogChild) => `children:[${coremodStr}?.Percentage(${ogChild}) ?? ${ogChild}]`,
       },
     ],
   },

--- a/src/renderer/coremods/messagePopover/plaintextPatches.ts
+++ b/src/renderer/coremods/messagePopover/plaintextPatches.ts
@@ -8,7 +8,7 @@ export default [
         match:
           /(Fragment,{children:\[)(.{0,200}children:\[.{0,20}?(\w{1,3})\({.{0,5}\s?key:"copy-id".{0,20}channel:(.{1,3})[,}].{0,20}message:(.{1,3})[,}])/,
         replace: (_, prefix, suffix, makeButton, channel, message) =>
-          `${prefix}...replugged.coremods.coremods.messagePopover._buildPopoverElements(${message},${channel},${makeButton}),${suffix}`,
+          `${prefix}...(replugged.coremods.coremods.messagePopover?._buildPopoverElements(${message},${channel},${makeButton}) ?? []),${suffix}`,
       },
     ],
   },

--- a/src/renderer/coremods/notices/plaintextPatches.tsx
+++ b/src/renderer/coremods/notices/plaintextPatches.tsx
@@ -9,7 +9,7 @@ export default [
       {
         match: /(\w+\.base,children:\[)(.+?}\)),/,
         replace: (_, prefix, noticeWrapper) =>
-          `${prefix}${coremodStr}.AnnouncementContainer({originalRes:${noticeWrapper}}),`,
+          `${prefix}${coremodStr}?.AnnouncementContainer({originalRes:${noticeWrapper}}) ?? ${noticeWrapper},`,
       },
     ],
   },

--- a/src/renderer/coremods/settings/plaintextPatches.ts
+++ b/src/renderer/coremods/settings/plaintextPatches.ts
@@ -7,9 +7,9 @@ export default [
     find: "getPredicateSections",
     replacements: [
       {
-        match: /this\.props\.sections\.filter\((.+?)\)}/,
-        replace: (_, sections) =>
-          `${coremodStr}.insertSections(this.props.sections.filter(${sections}))};`,
+        match: /(this\.props\.sections\.filter\(.+?\))}/,
+        replace: (_, filteredSections) =>
+          `${coremodStr}?.insertSections(${filteredSections}) ?? ${filteredSections}};`,
       },
     ],
   },
@@ -18,7 +18,7 @@ export default [
     replacements: [
       {
         match: /appArch,children:.{0,200}?className:\w+\.line,.{0,100}children:\w+}\):null/,
-        replace: `$&,${coremodStr}.VersionInfo()`,
+        replace: `$&,${coremodStr}?.VersionInfo() ?? null`,
       },
     ],
   },

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -8,8 +8,7 @@ type DiscordSplashWindow = Window & {
 
 // Splash screen
 if ((window as DiscordSplashWindow).DiscordSplash) {
-  await replugged.ignition.startSplash();
+  void replugged.ignition.startSplash();
 } else {
-  await replugged.plugins.loadAll();
-  await replugged.ignition.ignite();
+  void replugged.ignition.ignite();
 }

--- a/src/renderer/managers/coremods.ts
+++ b/src/renderer/managers/coremods.ts
@@ -77,20 +77,17 @@ export async function stopAll(): Promise<void> {
   await Promise.allSettled(Object.values(coremods).map((c) => c.stop?.()));
 }
 
-export function runPlaintextPatches(): Promise<void> {
-  return new Promise<void>((res) => {
-    [
-      experimentsPlaintext,
-      notrackPlaintext,
-      noDevtoolsWarningPlaintext,
-      messagePopover,
-      notices,
-      contextMenu,
-      languagePlaintext,
-      commandsPlaintext,
-      settingsPlaintext,
-      badgesPlaintext,
-    ].forEach(patchPlaintext);
-    res();
-  });
+export function runPlaintextPatches(): void {
+  [
+    experimentsPlaintext,
+    notrackPlaintext,
+    noDevtoolsWarningPlaintext,
+    messagePopover,
+    notices,
+    contextMenu,
+    languagePlaintext,
+    commandsPlaintext,
+    settingsPlaintext,
+    badgesPlaintext,
+  ].forEach(patchPlaintext);
 }

--- a/src/renderer/managers/plugins.ts
+++ b/src/renderer/managers/plugins.ts
@@ -86,20 +86,19 @@ export async function start(id: string): Promise<void> {
           );
           plugin.exports = pluginExports;
           await pluginExports.start?.();
+          if (plugin.hasCSS) {
+            if (styleElements.has(plugin.manifest.id)) {
+              // Remove old style element in case it wasn't removed properly
+              styleElements.get(plugin.manifest.id)?.remove();
+            }
+
+            const el = loadStyleSheet(
+              `replugged://plugin/${plugin.path}/${plugin.manifest.renderer?.replace(/\.js$/, ".css")}`,
+            );
+            styleElements.set(plugin.manifest.id, el);
+          }
         })(),
       ]);
-    }
-
-    if (plugin.hasCSS) {
-      if (styleElements.has(plugin.manifest.id)) {
-        // Remove old style element in case it wasn't removed properly
-        styleElements.get(plugin.manifest.id)?.remove();
-      }
-
-      const el = loadStyleSheet(
-        `replugged://plugin/${plugin.path}/${plugin.manifest.renderer?.replace(/\.js$/, ".css")}`,
-      );
-      styleElements.set(plugin.manifest.id, el);
     }
 
     running.add(plugin.manifest.id);

--- a/src/renderer/managers/plugins.ts
+++ b/src/renderer/managers/plugins.ts
@@ -93,7 +93,10 @@ export async function start(id: string): Promise<void> {
             }
 
             const el = loadStyleSheet(
-              `replugged://plugin/${plugin.path}/${plugin.manifest.renderer?.replace(/\.js$/, ".css")}`,
+              `replugged://plugin/${plugin.path}/${plugin.manifest.renderer?.replace(
+                /\.js$/,
+                ".css",
+              )}`,
             );
             styleElements.set(plugin.manifest.id, el);
           }

--- a/src/renderer/modules/i18n.ts
+++ b/src/renderer/modules/i18n.ts
@@ -1,13 +1,11 @@
 import { i18n } from "@common";
 import type { RepluggedTranslations } from "../../types";
 
-const strings = await RepluggedNative.i18n.getStrings();
-
 export let locale: string | undefined;
 export const messages = new Map();
 
-export function load(): void {
-  loadAllStrings(strings);
+export async function load(): Promise<void> {
+  loadAllStrings(await RepluggedNative.i18n.getStrings());
 
   locale = i18n._chosenLocale;
 

--- a/src/renderer/modules/webpack/patch-load.ts
+++ b/src/renderer/modules/webpack/patch-load.ts
@@ -17,33 +17,6 @@ import { patchModuleSource } from "./plaintext-patch";
 export let wpRequire: WebpackRequire | undefined;
 export let webpackChunks: WebpackRawModules | undefined;
 
-let signalReady: () => void;
-let ready = false;
-
-/**
- * @internal
- * @hidden
- */
-export const waitForReady = new Promise<void>(
-  (resolve) =>
-    (signalReady = () => {
-      ready = true;
-      resolve();
-    }),
-);
-
-/**
- * @internal
- * @hidden
- */
-export let signalStart: () => void;
-
-/**
- * @internal
- * @hidden
- */
-export const waitForStart = new Promise<void>((resolve) => (signalStart = resolve));
-
 const patchedModules = new Set<string>();
 
 /**
@@ -53,8 +26,7 @@ const patchedModules = new Set<string>();
  */
 export const sourceStrings: Record<number, string> = {};
 
-async function patchChunk(chunk: WebpackChunk): Promise<void> {
-  await waitForStart;
+function patchChunk(chunk: WebpackChunk): void {
   const modules = chunk[1];
   for (const id in modules) {
     if (patchedModules.has(id)) continue;
@@ -85,8 +57,8 @@ async function patchChunk(chunk: WebpackChunk): Promise<void> {
 function patchPush(webpackChunk: WebpackChunkGlobal): void {
   let original = webpackChunk.push;
 
-  async function handlePush(chunk: WebpackChunk): Promise<unknown> {
-    await patchChunk(chunk);
+  function handlePush(chunk: WebpackChunk): unknown {
+    patchChunk(chunk);
     return original.call(webpackChunk, chunk);
   }
 
@@ -114,6 +86,9 @@ function loadWebpackModules(chunksGlobal: WebpackChunkGlobal): void {
       if (wpRequire.c && !webpackChunks) webpackChunks = wpRequire.c;
 
       if (r) {
+        // The first batch of modules are added inline via r.m rather than being pushed
+        patchChunk([[], r.m]);
+
         r.d = (module: unknown, exports: Record<string, () => unknown>) => {
           for (const prop in exports) {
             if (
@@ -136,46 +111,32 @@ function loadWebpackModules(chunksGlobal: WebpackChunkGlobal): void {
   // Patch previously loaded chunks
   if (Array.isArray(chunksGlobal)) {
     for (const loadedChunk of chunksGlobal) {
-      void patchChunk(loadedChunk);
+      patchChunk(loadedChunk);
     }
   }
 
   patchPush(chunksGlobal);
-  signalReady();
-
-  // There is some kind of race condition where chunks are not patched ever, so this should make sure everything gets patched
-  // This is a temporary workaround that should be removed once we figure out the real cause
-  setInterval(() => {
-    if (Array.isArray(chunksGlobal)) {
-      for (const loadedChunk of chunksGlobal) {
-        void patchChunk(loadedChunk);
-      }
-    }
-  }, 1000);
 }
 
 // Intercept the webpack chunk global as soon as Discord creates it
-
-// Because using a timer is bad, thanks Ven
-// https://github.com/Vendicated/Vencord/blob/ef353f1d66dbf1d14e528830d267aac518ed1beb/src/webpack/patchWebpack.ts
-let webpackChunk: WebpackChunkGlobal | undefined;
-
-if (window.webpackChunkdiscord_app) {
-  webpackChunk = window.webpackChunkdiscord_app;
-  loadWebpackModules(webpackChunk!);
-} else {
-  Object.defineProperty(window, "webpackChunkdiscord_app", {
-    get: () => webpackChunk,
-    set: (v) => {
-      // Only modify if the global has actually changed
-      // We don't need to check if push is the special webpack push,
-      // because webpack will go over the previously loaded modules
-      // when it sets the custom push method.
-      if (v !== webpackChunk && !ready) {
-        loadWebpackModules(v);
-      }
-      webpackChunk = v;
-    },
-    configurable: true,
-  });
+export function interceptChunksGlobal(): void {
+  if (window.webpackChunkdiscord_app) {
+    loadWebpackModules(window.webpackChunkdiscord_app);
+  } else {
+    let webpackChunk: WebpackChunkGlobal | undefined;
+    Object.defineProperty(window, "webpackChunkdiscord_app", {
+      get: () => webpackChunk,
+      set: (v) => {
+        // Only modify if the global has actually changed
+        // We don't need to check if push is the special webpack push,
+        // because webpack will go over the previously loaded modules
+        // when it sets the custom push method.
+        if (v !== webpackChunk) {
+          loadWebpackModules(v);
+        }
+        webpackChunk = v;
+      },
+      configurable: true,
+    });
+  }
 }

--- a/src/renderer/modules/webpack/patch-load.ts
+++ b/src/renderer/modules/webpack/patch-load.ts
@@ -62,8 +62,8 @@ function patchPush(webpackChunk: WebpackChunkGlobal): void {
     return original.call(webpackChunk, chunk);
   }
 
-  // https://github.com/Vendicated/Vencord/blob/e4701769a5b8e0a71dba0e26bc311ff6e34eadf7/src/webpack/patchWebpack.ts#L93-L98
-  handlePush.bind = (...args: unknown[]) => original.bind([...args]);
+  // From YofukashiNo: https://discord.com/channels/1000926524452647132/1000955965304221728/1258946431348375644
+  handlePush.bind = original.bind.bind(original);
 
   Object.defineProperty(webpackChunk, "push", {
     get: () => handlePush,

--- a/src/types/webpack.ts
+++ b/src/types/webpack.ts
@@ -20,7 +20,7 @@ export type WebpackRawModules = Record<string | number, RawModule>;
 export type WebpackRequire = ((e: number) => unknown) & {
   c?: WebpackRawModules;
   d: (module: unknown, exports: Record<string, () => unknown>) => void;
-  m: WebpackChunk;
+  m: WebpackChunk[1];
 };
 
 export type WebpackModule = (


### PR DESCRIPTION
Discord changed their webpack configuration a little bit, so that most of the common modules we need are now declared inline rather than pushed to the global array of chunks. This update fixes our injection to account for this change. It also includes fixes for the plaintext patches in our coremods, so that if initialization fails, missing coremods in the `replugged.coremods.coremods` namespace will not cause a React crash.

In the process, I've also swapped out the wait/signal start mechanism for a simpler means of intercepting the creation of Webpack chunks/modules. It adds needless complexity and is likely complicit in our perennial crashing issues. So far, with this mechanism removed, Replugged loads reliably on my machine. More testing is needed, especially on Windows and Linux, to confirm these stability improvements.