### PR TITLE
fix: correct badge colors

### DIFF
--- a/src/renderer/coremods/badges/badge.css
+++ b/src/renderer/coremods/badges/badge.css
@@ -1,9 +1,3 @@
-[class*="containerWithContent"] {
-  min-height: -webkit-fit-content;
-  min-height: -moz-fit-content;
-  min-height: fit-content;
-}
-
 .replugged-badge {
   padding: 3px;
   box-sizing: border-box;

--- a/src/renderer/coremods/badges/index.tsx
+++ b/src/renderer/coremods/badges/index.tsx
@@ -24,7 +24,6 @@ interface APIRepluggedCustomBadge {
 }
 
 interface APIRepluggedBadges {
-  [key: string]: boolean | APIRepluggedCustomBadge;
   developer: boolean;
   staff: boolean;
   support: boolean;
@@ -152,7 +151,7 @@ export async function start(): Promise<void> {
       }
 
       badgeElements.forEach((badgeElement) => {
-        if (badgeCache[badgeElement.id]) {
+        if (badgeElement.id in badgeCache) {
           const { component, ...props } = badgeElement;
           const badgeColor = badgeCache.custom.color;
 

--- a/src/renderer/coremods/badges/index.tsx
+++ b/src/renderer/coremods/badges/index.tsx
@@ -154,12 +154,15 @@ export async function start(): Promise<void> {
       badgeElements.forEach((badgeElement) => {
         if (badgeCache[badgeElement.id]) {
           const { component, ...props } = badgeElement;
+          const badgeColor = badgeCache.custom.color;
 
           newBadges.push({
             ...props,
             icon: "replugged",
             component: React.createElement(component, {
-              color: badgeCache.custom.color ?? DISCORD_BLURPLE,
+              color:
+                (badgeColor && (badgeColor.startsWith("#") ? badgeColor : `#${badgeColor}`)) ??
+                DISCORD_BLURPLE,
             }),
           });
         }

--- a/src/renderer/coremods/badges/plaintextPatches.ts
+++ b/src/renderer/coremods/badges/plaintextPatches.ts
@@ -2,23 +2,7 @@ import type { PlaintextPatch } from "src/types";
 
 export default [
   {
-    // Edit the UserProfileBadgeList component
-    find: ".profileBadge2",
-    replacements: [
-      {
-        // Add the "replugged-badge" class if it's our custom badge
-        match: /src:(\w+)\.src,className:\w+\(\)\({/,
-        replace: `$&["replugged-badge"]:$1.component,`,
-      },
-      {
-        // Change to a div and add a children for our custom badge
-        match: /"img",({.+?src:(\w+)\.src,)/,
-        replace: `$2.component?"div":"img",$1children:$2.component,`,
-      },
-    ],
-  },
-  {
-    // Edit the ProfileBadges component (new profile design)
+    // Edit the ProfileBadges component
     find: /\.container,\w+\),"aria-label":\w+.\w+\.Messages\.PROFILE_USER_BADGES/,
     replacements: [
       // Add the "replugged-badge" class if it's our custom badge


### PR DESCRIPTION
The colors of the badges were not applied correctly because the hashtag was missing at the beginning.

EDIT: removed plaintext patch and css to change old profile badges (now completely removed from code).