### PR TITLE
More coremods/modules fixes

### DIFF
--- a/src/renderer/coremods/badges/index.tsx
+++ b/src/renderer/coremods/badges/index.tsx
@@ -151,7 +151,7 @@ export async function start(): Promise<void> {
       }
 
       badgeElements.forEach((badgeElement) => {
-        if (badgeElement.id in badgeCache) {
+        if (badgeCache[badgeElement.id as keyof APIRepluggedBadges]) {
           const { component, ...props } = badgeElement;
           const badgeColor = badgeCache.custom.color;
 

--- a/src/renderer/coremods/notices/index.tsx
+++ b/src/renderer/coremods/notices/index.tsx
@@ -37,11 +37,7 @@ function Announcement({
   );
 }
 
-export function AnnouncementContainer({
-  originalRes,
-}: {
-  originalRes: React.ReactElement;
-}): React.ReactElement | null {
+export function AnnouncementContainer(): React.ReactElement | undefined {
   const [announcement, setAnnouncement] = React.useState<RepluggedAnnouncement | undefined>(
     undefined,
   );
@@ -57,5 +53,5 @@ export function AnnouncementContainer({
     };
   }, []);
 
-  return announcement ? <Announcement {...announcement} /> : originalRes;
+  return announcement && <Announcement {...announcement} />;
 }

--- a/src/renderer/coremods/notices/plaintextPatches.ts
+++ b/src/renderer/coremods/notices/plaintextPatches.ts
@@ -7,9 +7,8 @@ export default [
     find: /hasNotice:\w+,sidebarTheme:\w+/,
     replacements: [
       {
-        match: /(\w+\.base,children:\[.{0,50})(\w+\.\w+\?null.{10,30}}\)),/,
-        replace: (_, prefix, noticeWrapper) =>
-          `${prefix}${coremodStr}?.AnnouncementContainer?${coremodStr}.AnnouncementContainer({originalRes:${noticeWrapper}}):${noticeWrapper},`,
+        match: /\w+\.base,children:\[/,
+        replace: `$&${coremodStr}?.AnnouncementContainer?.(),`,
       },
     ],
   },

--- a/src/renderer/coremods/rpc/index.ts
+++ b/src/renderer/coremods/rpc/index.ts
@@ -39,9 +39,6 @@ type RPCMod = { commands: Commands };
 let commands: Commands = {};
 
 async function injectRpc(): Promise<void> {
-  //const rpcValidatorMod = await waitForProps<{
-  //  fetchApplicationsRPC: (socket: Socket, client_id: string, origin: string) => Promise<void>;
-  //}>("fetchApplicationsRPC");
   const rpcValidatorMod = await waitForModule<
     Record<string, (socket: Socket, client_id: string, origin: string) => Promise<void>>
   >(filters.bySource("Invalid Client ID"));

--- a/src/renderer/modules/common/constants.ts
+++ b/src/renderer/modules/common/constants.ts
@@ -1,13 +1,11 @@
 import { virtualMerge } from "src/renderer/util";
-import { filters, getExportsForProps, waitForModule } from "../webpack";
+import { filters, getExportsForProps, waitForModule, waitForProps } from "../webpack";
 
 type StringConcat = (...rest: string[]) => string;
 
-//const ConstantsCommon = await waitForProps<Record<string, unknown>>("Links", "RPCCommands");
 const ConstantsCommon = await waitForModule<Record<string, unknown>>(
   filters.bySource("dis.gd/request"),
 );
-//const Constants = await waitForProps<Record<string, unknown>>("Endpoints", "Routes");
 const Constants = await waitForModule<Record<string, unknown>>(
   filters.bySource("users/@me/relationships"),
 );
@@ -18,10 +16,7 @@ export const Permissions = getExportsForProps<Record<string, bigint>>(ConstantsC
   "MANAGE_GUILD",
 ]);
 // OAuth2Scopes
-export const Scopes = getExportsForProps<Record<string, string>>(ConstantsCommon, [
-  "BOT",
-  "GUILDS",
-])!;
+export const Scopes = await waitForProps<Record<string, string>>("BOT", "GUILDS");
 // RPCCloseCodes
 export const RPCErrors = getExportsForProps<Record<string, string | number>>(ConstantsCommon, [
   "RATELIMITED",
@@ -72,16 +67,10 @@ export const UserFlags = getExportsForProps<Record<string, string | number>>(Con
 ])!;
 
 // ThemeColor
-//Ambiguous: should this be the just-dashed-names or --var(css-var-strings)?
-// Go with the latter for now.
-/*
 export const CSSVariables = await waitForProps<Record<string, string>>(
   "TEXT_NORMAL",
   "BACKGROUND_PRIMARY",
 );
-*/
-// We *should* be able to do props, but there's so much extra junk with the current search implementation.
-export const CSSVariables = await waitForModule(filters.bySource('="var(--background-floating)"'));
 
 interface ColorResponse {
   hex: () => string;
@@ -127,11 +116,9 @@ interface ColorMod {
   shadows: Record<string, ShadowColor>;
   // eslint-disable-next-line @typescript-eslint/naming-convention
   unsafe_rawColors: Record<string, UnsafeRawColor>;
+  layout: Record<string, string>;
 }
 
-// This could really be a search by props, for unsafe_rawColors.
-export const ColorGenerator = await waitForModule<ColorMod>(
-  filters.bySource(/\w+\.unsafe_rawColors\[\w+\]\.resolve\(\w+\)/),
-);
+export const ColorGenerator = await waitForProps<ColorMod>("unsafe_rawColors", "layout");
 
 export const Themes = ColorGenerator.themes;


### PR DESCRIPTION
- Separate the mod's notices from Discord's notices; this will avoid breaking the app's notices if something goes wrong with our custom system.
- Fixes wrong badges being shown on profiles.
- Fixed Scope constants being undefined.
- Correct the CSSVariables module in constants.
- Code cleanup.