### PR TITLE
Coremod fixes

### DIFF
--- a/src/renderer/coremods/badges/plaintextPatches.ts
+++ b/src/renderer/coremods/badges/plaintextPatches.ts
@@ -12,7 +12,7 @@ export default [
       },
       // Change to a div and add a children for our custom badge
       {
-        match: /"img",({.+?\((\w+)\.icon\),)/,
+        match: /"img",(.{20,50}?\((\w+)\.icon\),)/,
         replace: `$2.component?"div":"img",$1children:$2.component,`,
       },
     ],

--- a/src/renderer/coremods/notrack/plaintextPatches.ts
+++ b/src/renderer/coremods/notrack/plaintextPatches.ts
@@ -5,8 +5,8 @@ export default [
     find: "AnalyticsActionHandlers.handleTrack",
     replacements: [
       {
-        match: /=>\w+\.AnalyticsActionHandlers\.handle\w+\([^)]*\)/g,
-        replace: "=>{}",
+        match: /(\(\)|\w+)=>\w+\.AnalyticsActionHandlers\.handle\w+\([^)]*\)/g,
+        replace: "arg=>{arg?.resolve?.()}",
       },
     ],
   },


### PR DESCRIPTION
- Fix For Badges coremod crashing while trying to render custom badge.
- Fix For NoTrack coremod preventing discord's setting to be changed. (Can be tested with audio subsystem)