### PR TITLE
Context Menu API PlaintextPatch

### DIFF
--- a/src/renderer/coremods/contextMenu/plaintextPatches.ts
+++ b/src/renderer/coremods/contextMenu/plaintextPatches.ts
@@ -15,7 +15,7 @@ export default [
     find: "navId",
     replacements: [
       {
-        match: /navId:(?![^}]*}=)[^)]*\)/g,
+        match: /navId:(?![^(})]*?}=)[^)]*?\)/g,
         replace: (suffix) => `data:arguments,${suffix}`,
       },
     ],


### PR DESCRIPTION
Made the regex first math to be non greedy and match only for `}=` to stop.

Effects can be observed on `ManageStreams` menu i.e the patch was not getting applied there. 

