### PR TITLE
feat: add support for desktop visual refresh

### DIFF
--- a/src/renderer/coremods/notices/index.tsx
+++ b/src/renderer/coremods/notices/index.tsx
@@ -12,7 +12,7 @@ function Announcement({
   onClose,
 }: RepluggedAnnouncement): React.ReactElement {
   return (
-    <Notice className="replugged-notice" color={color}>
+    <Notice color={color}>
       <NoticeCloseButton
         onClick={() => {
           onClose?.();

--- a/src/renderer/coremods/notices/plaintextPatches.ts
+++ b/src/renderer/coremods/notices/plaintextPatches.ts
@@ -4,11 +4,23 @@ const coremodStr = "replugged.coremods.coremods.notices";
 
 export default [
   {
+    // Add the AnnouncementContainer to the AppView component children
     find: /hasNotice:\w+,sidebarTheme:\w+/,
     replacements: [
       {
         match: /\w+\.base,"data-fullscreen":\w+,children:\[/,
         replace: `$&${coremodStr}?.AnnouncementContainer?.(),`,
+      },
+    ],
+  },
+  {
+    // Edit the NoticeStore's function "hasNotice" to return true if there are our notices
+    // This is used in some places to decide whether to apply certain class names or not
+    find: /"displayName","NoticeStore"/,
+    replacements: [
+      {
+        match: /(hasNotice\(\){return )(null!=\w+&&null!=\w+\.type)/,
+        replace: `$1($2)||replugged.notices.announcements.length>0`,
       },
     ],
   },

--- a/src/renderer/coremods/settings/pages/Addons.css
+++ b/src/renderer/coremods/settings/pages/Addons.css
@@ -1,13 +1,14 @@
 .replugged-addon-cards {
   display: grid;
-  gap: 20px;
+  gap: var(--space-md);
 }
 
 .replugged-addon-card {
-  background-color: var(--background-secondary);
+  background-color: var(--bg-base-secondary);
+  border: 1px solid var(--bg-mod-faint);
   width: 100%;
-  padding: 15px;
-  border-radius: 5px;
+  padding: var(--spacing-16);
+  border-radius: var(--radius-sm);
 }
 
 .replugged-addon-icon,

--- a/src/renderer/coremods/settings/pages/Addons.css
+++ b/src/renderer/coremods/settings/pages/Addons.css
@@ -5,7 +5,7 @@
 
 .replugged-addon-card {
   background-color: var(--bg-base-secondary);
-  border: 1px solid var(--bg-mod-faint);
+  border: 1px solid var(--border-subtle);
   width: 100%;
   padding: var(--spacing-16);
   border-radius: var(--radius-sm);

--- a/src/renderer/coremods/settings/pages/Updater.css
+++ b/src/renderer/coremods/settings/pages/Updater.css
@@ -1,13 +1,14 @@
 .replugged-updater-header {
-  margin-bottom: 10px;
+  margin-bottom: var(--spacing-12);
 }
 
 .replugged-updater-items {
-  gap: 8px;
+  gap: var(--space-xs);
 }
 
 .replugged-updater-item {
-  background-color: var(--background-secondary);
-  padding: 15px;
-  border-radius: 5px;
+  background-color: var(--bg-base-secondary);
+  border: 1px solid var(--bg-mod-faint);
+  padding: var(--spacing-16);
+  border-radius: var(--radius-sm);
 }

--- a/src/renderer/coremods/settings/pages/Updater.css
+++ b/src/renderer/coremods/settings/pages/Updater.css
@@ -8,7 +8,7 @@
 
 .replugged-updater-item {
   background-color: var(--bg-base-secondary);
-  border: 1px solid var(--bg-mod-faint);
+  border: 1px solid var(--border-subtle);
   padding: var(--spacing-16);
   border-radius: var(--radius-sm);
 }

--- a/src/renderer/coremods/settings/pages/Updater.tsx
+++ b/src/renderer/coremods/settings/pages/Updater.tsx
@@ -1,5 +1,5 @@
 import { toast } from "@common";
-import { intl } from "@common/i18n";
+import { t as discordT, intl } from "@common/i18n";
 import React from "@common/react";
 import { Button, Divider, Flex, Notice, SliderItem, SwitchItem, Text, Tooltip } from "@components";
 import { Logger } from "@replugged";
@@ -134,8 +134,12 @@ export const Updater = (): React.ReactElement => {
           const hours = Math.floor(value / 60);
           const minutes = value % 60;
 
-          const hourString = hours > 0 ? `${hours}h` : "";
-          const minuteString = minutes > 0 ? `${minutes}m` : "";
+          const hourString =
+            hours > 0 ? intl.formatToPlainString(discordT.DURATION_HOURS_SHORT, { hours }) : "";
+          const minuteString =
+            minutes > 0
+              ? intl.formatToPlainString(discordT.DURATION_MINUTES_SHORT, { minutes })
+              : "";
 
           const label = [hourString, minuteString].filter(Boolean).join(" ");
           return label;


### PR DESCRIPTION
- [5260c639386e4f6d0a5cd05b4af2f451bcf35b30] Styles now use the new spacing variables to be more consistent with everything else. This also adds support for UI density, specifically how much space there is between each addon in the list. Addon cards now have a subtle border, which is now applied in all cards in the app, again for consistency and for greater distinction when in light or onyx theme.
![image](https://github.com/user-attachments/assets/129c11c4-c382-4851-a7e4-fb33e3d5d34c)
![image](https://github.com/user-attachments/assets/4dde025d-3264-4e55-bebc-cbc1da35af1e)
- [22ceefff8b7d4fe7cf26dfc326f1b3344f9a7595] Patch the "hasNotice" function to handle style changes if notices are present; class names are added to the outer frame to add rounded edges or not.
- [a6575cad2e33097aff0969bb7c7245ce229d5632] Update duration formatting in updater settings to use localized strings.
![image](https://github.com/user-attachments/assets/dee86fcd-413b-4118-b1ab-3c56630c0de9)
