### PR TITLE
fix: update IPC version retrieval to use synchronous method

### DIFF
--- a/src/main/ipc/installer.ts
+++ b/src/main/ipc/installer.ts
@@ -1,5 +1,5 @@
 import { ipcMain } from "electron";
-import { readFile } from "fs/promises";
+import { readFileSync } from "fs";
 import { writeFile as originalWriteFile } from "original-fs";
 import { join, resolve, sep } from "path";
 import { WEBSITE_URL } from "src/constants";
@@ -244,14 +244,15 @@ ipcMain.handle(
   },
 );
 
-ipcMain.handle(RepluggedIpcChannels.GET_REPLUGGED_VERSION, async () => {
+ipcMain.on(RepluggedIpcChannels.GET_REPLUGGED_VERSION, (event) => {
   const path = join(__dirname, "package.json");
   try {
-    const packageJson = JSON.parse(await readFile(path, "utf8"));
-    return packageJson.version;
+    const packageJson = JSON.parse(readFileSync(path, "utf8"));
+    event.returnValue = packageJson.version;
   } catch (err) {
     if (err && typeof err === "object" && "code" in err && err.code === "ENOENT") {
-      return "dev";
+      event.returnValue = "dev";
+      return;
     }
     throw err;
   }

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -12,10 +12,7 @@ import type {
   RepluggedTheme,
 } from "./types";
 
-let version = "";
-void ipcRenderer.invoke(RepluggedIpcChannels.GET_REPLUGGED_VERSION).then((v) => {
-  version = v;
-});
+const version = ipcRenderer.sendSync(RepluggedIpcChannels.GET_REPLUGGED_VERSION);
 
 const RepluggedNative = {
   themes: {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -91,7 +91,7 @@ const RepluggedNative = {
       ipcRenderer.invoke(RepluggedIpcChannels.DOWNLOAD_REACT_DEVTOOLS),
   },
 
-  getVersion: () => version,
+  getVersion: (): string => version,
 
   // @todo We probably want to move these somewhere else, but I'm putting them here for now because I'm too lazy to set anything else up
 };


### PR DESCRIPTION
Discord client with v4.9.0 got faster, when it initializes the updater it's still waiting to get the version from `package.json`.
This fixes an issue with the updater settings showing an update available for Replugged everytime.