### PR TITLE
Copy logo as file instead of data url

### DIFF
--- a/scripts/build.mts
+++ b/scripts/build.mts
@@ -73,8 +73,10 @@ const contexts = await Promise.all([
     target: `chrome${CHROME_VERSION}`,
     outfile: `${distDir}/renderer.js`,
     format: "esm",
+    assetNames: "assets/[hash]",
+    publicPath: "replugged://",
     loader: {
-      ".png": "dataurl",
+      ".png": "file",
     },
   }),
 ]);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -176,6 +176,9 @@ electron.app.once("ready", () => {
       case "renderer.css":
         filePath = join(__dirname, "./renderer.css");
         break;
+      case "assets":
+        filePath = join(__dirname, reqUrl.hostname, reqUrl.pathname);
+        break;
       case "quickcss":
         filePath = join(CONFIG_PATHS.quickcss, reqUrl.pathname);
         break;


### PR DESCRIPTION
This results in much cleaner URL like `replugged://assets/NKRVPFLH.png` instead of 300 KB Data URL directly in the `BOT_AVATARS` object. 

