### PR TITLE
React Devtools SourceURL Fix

### DIFF
--- a/src/renderer/modules/webpack/plaintext-patch.ts
+++ b/src/renderer/modules/webpack/plaintext-patch.ts
@@ -46,7 +46,7 @@ export function patchModuleSource(mod: WebpackModule, id: string): WebpackModule
     return (0, eval)(
       `${
         patchedSource.startsWith("function(") ? `0,${patchedSource}` : patchedSource
-      }\n// Patched by: ${patchedBy.filter(Boolean).join(", ")}\n//# sourceURL=https://discord.com/assets/patched/PatchedWebpack-${id}`,
+      }\n// Patched by: ${patchedBy.filter(Boolean).join(", ")}\n//# sourceURL=${window.location.origin}/assets/patched/PatchedWebpack-${id}`,
     );
   } catch (err) {
     logger.error(`PatchedWebpack-${id}`, err);


### PR DESCRIPTION
In the newer versions of RDT (tested with 6.1.2), it tries to fetch the source URL and doesn't open the module in the sources tab. 
Replacing the partial URL with the full URL fixes this as the source URL perfectly matches what it is trying to fetch. 

Attaching React Devtools 6.1.2 if you wanna test. 
[rdt_6.1.2.zip](https://github.com/user-attachments/files/20690808/rdt_6.1.2.zip)
