### PR TITLE
Settings Search 

### DIFF
--- a/src/renderer/coremods/settings/index.tsx
+++ b/src/renderer/coremods/settings/index.tsx
@@ -5,6 +5,9 @@ import { t } from "src/renderer/modules/i18n";
 import { Divider, Header, Section, insertSections, settingsTools } from "./lib";
 import { General, Plugins, QuickCSS, Themes, Updater } from "./pages";
 
+// To hide "No Search Results" when replugged is still there
+import "./searchResults.css";
+
 const injector = new Injector();
 
 export { insertSections };

--- a/src/renderer/coremods/settings/lib.tsx
+++ b/src/renderer/coremods/settings/lib.tsx
@@ -4,6 +4,11 @@ import type {
   Section as SectionType,
   SettingsTools,
 } from "../../../types/coremods/settings";
+import { filters, getFunctionBySource, waitForModule } from "@webpack";
+
+export const getQuery = await waitForModule(
+  filters.bySource('query:"",isActive:!1,selected:null'),
+).then((c) => getFunctionBySource<() => string>(c, '.useField("query")')!);
 
 const getPos = (pos: number | undefined): number => pos ?? -4;
 
@@ -15,6 +20,7 @@ export const Section = ({
   elem,
   pos,
   fromEnd,
+  tabPredicate,
 }: {
   name: string;
   _id?: string;
@@ -23,6 +29,7 @@ export const Section = ({
   elem: (args: unknown) => React.ReactElement;
   pos?: number;
   fromEnd?: boolean;
+  tabPredicate?: (query: string) => boolean;
 }): SectionType => ({
   section: name,
   _id,
@@ -30,18 +37,22 @@ export const Section = ({
   color,
   element: elem,
   pos: getPos(pos),
+  className: `rp-settingsItem ${name}`,
   fromEnd: fromEnd ?? getPos(pos) < 0,
+  tabPredicate: tabPredicate && (() => tabPredicate(getQuery())),
 });
 
 export const Divider = (pos?: number): SectionType => ({
   section: "DIVIDER",
   pos: getPos(pos),
+  tabPredicate: () => !getQuery(),
 });
 
 export const Header = (label: string | LabelCallback, pos?: number): SectionType => ({
   section: "HEADER",
   label,
   pos: getPos(pos),
+  tabPredicate: () => !getQuery(),
 });
 
 export const settingsTools: SettingsTools = {

--- a/src/renderer/coremods/settings/searchResults.css
+++ b/src/renderer/coremods/settings/searchResults.css
@@ -1,0 +1,3 @@
+.rp-settingsItem + div:has(> img[src="/assets/42baa6a9f56788f1.svg"]) {
+  display: none;
+}

--- a/src/types/coremods/settings.ts
+++ b/src/types/coremods/settings.ts
@@ -10,6 +10,8 @@ export interface Section {
   element?: (args: unknown) => React.ReactElement;
   pos: number;
   fromEnd?: boolean;
+  className?: string;
+  tabPredicate?: () => boolean;
   // eslint-disable-next-line @typescript-eslint/naming-convention
   __$$label?: LabelCallback;
 }


### PR DESCRIPTION
Implemented settings search in the lib. 
Section Example 
```
 Section({
      name: "name",
      label: "example label",
      elem: () => null,
      tabPredicate: (query) => true,
    })
 ```
 Divider and header hide when searching. 


TODO: Implement search functionality for each section