### PR TITLE
feat: replugged-notice

### DIFF
--- a/src/renderer/coremods/notices/index.tsx
+++ b/src/renderer/coremods/notices/index.tsx
@@ -3,6 +3,8 @@ import { notices } from "@replugged";
 import type { RepluggedAnnouncement } from "src/types";
 import NoticeMod from "./noticeMod";
 
+import "./repluggedNotice.css";
+
 const { Notice, NoticeButton, NoticeButtonAnchor, NoticeCloseButton } = NoticeMod;
 
 function Announcement({
@@ -12,7 +14,7 @@ function Announcement({
   onClose,
 }: RepluggedAnnouncement): React.ReactElement {
   return (
-    <Notice color={color}>
+    <Notice color={color ?? "replugged-notice"}>
       <NoticeCloseButton
         onClick={() => {
           onClose?.();

--- a/src/renderer/coremods/notices/repluggedNotice.css
+++ b/src/renderer/coremods/notices/repluggedNotice.css
@@ -8,3 +8,14 @@
   );
   --custom-notice-text: #eeffed;
 }
+
+html[lang="ar"] .replugged-notice,
+html[lang="he"] .replugged-notice {
+  --custom-notice-background: linear-gradient(
+    to left,
+    #c0164b 0%,
+    #a40f91 33%,
+    #7a10b5 66%,
+    #4e10d2 100%
+  );
+}

--- a/src/renderer/coremods/notices/repluggedNotice.css
+++ b/src/renderer/coremods/notices/repluggedNotice.css
@@ -6,16 +6,5 @@
     #7a10b5 66%,
     #4e10d2 100%
   );
-  --custom-notice-text: #eeffed;
-}
-
-html[lang="ar"] .replugged-notice,
-html[lang="he"] .replugged-notice {
-  --custom-notice-background: linear-gradient(
-    to left,
-    #c0164b 0%,
-    #a40f91 33%,
-    #7a10b5 66%,
-    #4e10d2 100%
-  );
+  --custom-notice-text: var(--white-500);
 }

--- a/src/renderer/coremods/notices/repluggedNotice.css
+++ b/src/renderer/coremods/notices/repluggedNotice.css
@@ -1,0 +1,10 @@
+.replugged-notice {
+  --custom-notice-background: linear-gradient(
+    to right,
+    #c0164b 0%,
+    #a40f91 33%,
+    #7a10b5 66%,
+    #4e10d2 100%
+  );
+  --custom-notice-text: #eeffed;
+}


### PR DESCRIPTION
The default colour for notices made from the notice api is set to replugged gradient. 
Can be overwritten by just passing in any color from notice colors mod or custom classes. 
<img width="1097" height="231" alt="image" src="https://github.com/user-attachments/assets/5cd64461-864d-44d7-819f-9ff14d16f1bf" />
