### PR TITLE
Ephemeral Images Fix

### DIFF
--- a/src/renderer/coremods/commands/plaintextPatches.ts
+++ b/src/renderer/coremods/commands/plaintextPatches.ts
@@ -1,0 +1,15 @@
+import type { PlaintextPatch } from "src/types";
+import { REPLUGGED_CLYDE_ID } from "src/constants";
+
+export default [
+  {
+    find: "/\\.gif($|\\?|#)/i",
+    replacements: [
+      {
+        match: /getSrc\(\w+\){/,
+        replace: (prefix) =>
+          `${prefix}if(this.props.sourceMetadata.message.author.id==="${REPLUGGED_CLYDE_ID}")return this.props.src;`,
+      },
+    ],
+  },
+] as PlaintextPatch[];

--- a/src/renderer/managers/coremods.ts
+++ b/src/renderer/managers/coremods.ts
@@ -3,6 +3,7 @@ import { Logger } from "../modules/logger";
 import { patchPlaintext } from "../modules/webpack/plaintext-patch";
 
 import badgesPlaintext from "../coremods/badges/plaintextPatches";
+import commandsPlaintext from "../coremods/commands/plaintextPatches";
 import contextMenuPlaintext from "../coremods/contextMenu/plaintextPatches";
 import experimentsPlaintext from "../coremods/experiments/plaintextPatches";
 import languagePlaintext from "../coremods/language/plaintextPatches";
@@ -83,6 +84,7 @@ export async function stopAll(): Promise<void> {
 export function runPlaintextPatches(): void {
   [
     { patch: badgesPlaintext, name: "replugged.coremod.badges" },
+    { patch: commandsPlaintext, name: "replugged.coremod.commands" },
     { patch: contextMenuPlaintext, name: "replugged.coremod.contextMenu" },
     { patch: experimentsPlaintext, name: "replugged.coremod.experiments" },
     { patch: languagePlaintext, name: "replugged.coremod.language" },


### PR DESCRIPTION
Do not let Discord process image links in replugged's client-side messages

fixes: https://github.com/replugged-org/replugged/issues/713