### PR TITLE
feat: change logs to info and verbose

### DIFF
--- a/src/renderer/coremods/devCompanion/index.tsx
+++ b/src/renderer/coremods/devCompanion/index.tsx
@@ -60,7 +60,7 @@ function parseNode(node: Node): string | RegExp {
 }
 
 function parseFind(type: string, args: unknown[]): unknown {
-  devLogger.log(`Received find parsing request of type ${type} with args: ${args}`);
+  devLogger.info(`Received find parsing request of type ${type} with args: ${args}`);
   switch (type.replace("get", "")) {
     case "Module":
       return getModule(args[0] as Filter, { all: true });
@@ -97,7 +97,7 @@ export function initWs(isManual = false): void {
 
   ws.addEventListener("open", () => {
     wasConnected = true;
-    devLogger.log("Connected to WebSocket");
+    devLogger.info("Connected to WebSocket");
   });
 
   ws.addEventListener("error", (e) => {
@@ -111,7 +111,7 @@ export function initWs(isManual = false): void {
   ws.addEventListener("close", (e) => {
     if (!wasConnected && !hasErrored) return;
 
-    devLogger.log("Dev Companion Disconnected", e.code, e.reason);
+    devLogger.info("Dev Companion Disconnected", e.code, e.reason);
   });
 
   ws.addEventListener("message", (e) => {
@@ -134,7 +134,7 @@ export function initWs(isManual = false): void {
       ws.send(JSON.stringify(data));
     }
 
-    devLogger.log("Received Message:", type, "\n", data);
+    devLogger.info("Received Message:", type, "\n", data);
 
     switch (type) {
       case "testPatch": {

--- a/src/renderer/coremods/watcher/index.ts
+++ b/src/renderer/coremods/watcher/index.ts
@@ -31,7 +31,7 @@ export function start(): void {
         };
       }
 
-      logger.log(`Got request to reload ${addon.manifest.id}.`);
+      logger.info(`Got request to reload ${addon.manifest.id}.`);
 
       try {
         if (plugin) {

--- a/src/renderer/managers/plugins.ts
+++ b/src/renderer/managers/plugins.ts
@@ -105,7 +105,7 @@ export async function start(id: string): Promise<void> {
     }
 
     running.add(plugin.manifest.id);
-    logger.log(`Plugin started: ${plugin.manifest.name}`);
+    logger.verbose(`Plugin started: ${plugin.manifest.name}`);
   } catch (e) {
     logger.error(`Error starting plugin ${plugin?.manifest.name}`, e);
   }
@@ -145,7 +145,7 @@ export async function stop(id: string): Promise<void> {
     }
 
     running.delete(plugin.manifest.id);
-    logger.log(`Plugin stopped: ${plugin.manifest.name}`);
+    logger.verbose(`Plugin stopped: ${plugin.manifest.name}`);
   } catch (e) {
     logger.error(`Error stopping plugin ${plugin?.manifest.name}`, e);
   }

--- a/src/renderer/managers/updater.ts
+++ b/src/renderer/managers/updater.ts
@@ -111,7 +111,7 @@ export async function checkUpdate(id: string, verbose = true): Promise<void> {
     return;
   }
   if (!entity.path.endsWith(".asar")) {
-    if (verbose) logger.log(`Entity ${id} is not an ASAR file, cannot be updated`);
+    if (verbose) logger.verbose(`Entity ${id} is not an ASAR file, cannot be updated`);
     return;
   }
 
@@ -137,7 +137,7 @@ export async function checkUpdate(id: string, verbose = true): Promise<void> {
   const newVersion = res.manifest.version;
 
   if (newVersion === version) {
-    if (verbose) logger.log(`Entity ${id} is up to date`);
+    if (verbose) logger.verbose(`Entity ${id} is up to date`);
     updaterState.set(id, {
       available: false,
       lastChecked: Date.now(),
@@ -148,7 +148,7 @@ export async function checkUpdate(id: string, verbose = true): Promise<void> {
     return;
   }
 
-  logger.log(`Entity ${id} has an update available`);
+  logger.info(`Entity ${id} has an update available`);
   updaterState.set(id, {
     available: true,
     url: res.url,
@@ -165,14 +165,14 @@ export async function installUpdate(id: string, force = false, verbose = true): 
     return false;
   }
   if (!entity.path.endsWith(".asar")) {
-    if (verbose) logger.log(`Entity ${id} is not an ASAR file, cannot be updated`);
+    if (verbose) logger.verbose(`Entity ${id} is not an ASAR file, cannot be updated`);
     return false;
   }
 
   const updateSettings = getUpdateState(id);
 
   if (!force && !updateSettings?.available) {
-    if (verbose) logger.log(`Entity ${id} has no update available`);
+    if (verbose) logger.verbose(`Entity ${id} has no update available`);
     return false;
   }
 
@@ -202,7 +202,7 @@ export async function installUpdate(id: string, force = false, verbose = true): 
 
   completedUpdates.add(id);
 
-  logger.log(`Entity ${id} updated successfully`);
+  logger.info(`Entity ${id} updated successfully`);
 
   return true;
 }
@@ -218,14 +218,14 @@ export async function checkAllUpdates(autoCheck = false, verbose = false): Promi
 
   const addons = [...plugins, ...themes].filter(filterFn);
 
-  logger.log("Checking for updates");
+  logger.verbose("Checking for updates");
 
   await Promise.all([
     checkUpdate(REPLUGGED_ID, verbose),
     ...addons.map((addon) => checkUpdate(addon.manifest.id, verbose)),
   ]);
 
-  logger.log("All updates checked");
+  logger.verbose("All updates checked");
   updaterSettings.set("lastChecked", Date.now());
 }
 
@@ -269,11 +269,11 @@ async function autoUpdateCheck(): Promise<void> {
   // If it's not been long enough to check again, don't check
   // But we still want to try and show existing updates if they exist
   if (lastCheckedAgo >= checkMs) {
-    logger.log("Checking for updates (auto)");
+    logger.verbose("Checking for updates (auto)");
     await checkAllUpdates(true);
     updaterSettings.set("lastChecked", Date.now());
   } else {
-    logger.log("Skipping update check since it's too soon since the last check");
+    logger.verbose("Skipping update check since it's too soon since the last check");
   }
 
   // We only want to show a notification if:
@@ -287,7 +287,7 @@ async function autoUpdateCheck(): Promise<void> {
   const isFirstRun = !didRun;
   didRun = true;
   if (isAnUpdate && (areNewUpdates || isFirstRun)) {
-    logger.log("Showing update notification");
+    logger.verbose("Showing update notification");
 
     const { open } = await openSettingsModPromise;
 


### PR DESCRIPTION
changed `logger.log` to `verbose` or `info` to respect the filtering done by devtools. 
`logger.log` should only be used when the user needs to see it, no matter what as it does not follow these filters 