### PR TITLE
fix: dupe keys error

### DIFF
--- a/src/renderer/util.ts
+++ b/src/renderer/util.ts
@@ -328,7 +328,7 @@ export function virtualMerge<O extends ObjectType[]>(...objects: O): ExtractObje
 
   const handler: ProxyHandler<ExtractObjectType<O>> = {
     ownKeys() {
-      return objects.map((obj) => Reflect.ownKeys(obj)).flat();
+      return Array.from(new Set(objects.map((obj) => Reflect.ownKeys(obj)).flat()));
     },
   };
 


### PR DESCRIPTION
Fix an error related to ownKeys returning dupe keys
Can be tested with `Reflect.ownKeys(replugged.common.constants.raw)`