### PR TITLE
feat: export wpRequire and sourceStrings

### DIFF
--- a/src/renderer/modules/webpack/index.ts
+++ b/src/renderer/modules/webpack/index.ts
@@ -10,3 +10,5 @@ export { getById, getExportsForProps, getModule } from "./get-modules";
 export * as filters from "./filters";
 
 export * from "./helpers";
+
+export { sourceStrings, wpRequire } from "./patch-load";


### PR DESCRIPTION
Gives plugin devs access to `sourceStrings` and `wpRequire`. 
