### PR TITLE
chore: change to before

### DIFF
--- a/src/renderer/coremods/installer/index.tsx
+++ b/src/renderer/coremods/installer/index.tsx
@@ -95,15 +95,15 @@ async function injectLinks(): Promise<void> {
     Anchor: React.FC<React.PropsWithChildren<AnchorProps>>;
   };
   const anchorKey = getFunctionKeyBySource(exports, "")! as "Anchor"; // It's actually a mangled name, but TS can sit down and shut up
-  injector.instead(exports, anchorKey, (args, fn) => {
+  injector.before(exports, anchorKey, (args) => {
     const { href } = args[0];
-    if (!href) return fn(...args);
+    if (!href) return args;
     const installLink = parseInstallLink(href);
-    if (!installLink) return fn(...args);
+    if (!installLink) return args;
 
     args[0].onClick = (e) => triggerInstall(installLink, e);
 
-    return fn(...args);
+    return args;
   });
 
   const defaultRules = parser.defaultRules as typeof parser.defaultRules & {


### PR DESCRIPTION
Changed Installer Anchor patch to before instead. All it did was change args and call the function