### PR TITLE
QuickCSS "Redesign"

### DIFF
--- a/i18n/en-US.messages.d.ts
+++ b/i18n/en-US.messages.d.ts
@@ -1270,6 +1270,19 @@ export declare const messages: {
    */
   'REPLUGGED_QUICKCSS_CHANGES_APPLY': TypedIntlMessageGetter<{}>,
   /**
+   * Key: `NNLlfn`
+   * 
+   * ### Definition
+   * ```text
+   * You've popped out the editor to another window.
+   * ```
+   * 
+   * ### Problems
+   * 
+   * Missing translations: `bg`, `cs`, `da`, `de`, `el`, `en-GB`, `es-419`, `es-ES`, `fi`, `fr`, `hi`, `hr`, `hu`, `it`, `ja`, `ko`, `lt`, `nl`, `no`, `pl`, `pt-BR`, `ro`, `ru`, `sv-SE`, `th`, `tr`, `uk`, `vi`, `zh-CN`, `zh-TW`
+   */
+  'REPLUGGED_QUICKCSS_EDITOR_POPPED_OUT': TypedIntlMessageGetter<{}>,
+  /**
    * Key: `Nk3LNj`
    * 
    * ### Definition

--- a/i18n/en-US.messages.js
+++ b/i18n/en-US.messages.js
@@ -239,5 +239,6 @@ export default defineMessages({
   "REPLUGGED_SETTINGS_DISCORD_DEVTOOLS": "Enable Discord Internal DevTools",
   "REPLUGGED_SETTINGS_DISCORD_DEVTOOLS_DESC": "Replaces the help button in the title bar with Discord's internal developer tools (different from Chrome DevTools). This setting requires Discord experiments to be enabled first. **Requires restart**.",
   "REPLUGGED_SETTINGS_QUICKCSS_ENABLE": "Enable Quick CSS",
-  "REPLUGGED_SETTINGS_QUICKCSS_ENABLE_DESC": "Apply custom styles to Discord instantly. Change colors, layout, and appearance in real time without installing themes."
+  "REPLUGGED_SETTINGS_QUICKCSS_ENABLE_DESC": "Apply custom styles to Discord instantly. Change colors, layout, and appearance in real time without installing themes.",
+  "REPLUGGED_QUICKCSS_EDITOR_POPPED_OUT": "You've popped out the editor to another window."
 });

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -30,6 +30,9 @@ declare global {
       relaunch: () => void;
     };
     window: {
+      close(key: string): void;
+      maximize(key: string): void;
+      minimize(key: string): void;
       setDevtoolsCallbacks(onOpened?: (() => void) | null, onClosed?: (() => void) | null): void;
       focus(): void;
     };

--- a/src/renderer/coremods/settings/icons/Close.tsx
+++ b/src/renderer/coremods/settings/icons/Close.tsx
@@ -1,0 +1,8 @@
+export default (): React.ReactElement => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+    <path
+      fill="currentColor"
+      d="M17.3 18.7a1 1 0 0 0 1.4-1.4L13.42 12l5.3-5.3a1 1 0 0 0-1.42-1.4L12 10.58l-5.3-5.3a1 1 0 0 0-1.4 1.42L10.58 12l-5.3 5.3a1 1 0 1 0 1.42 1.4L12 13.42l5.3 5.3Z"
+    />
+  </svg>
+);

--- a/src/renderer/coremods/settings/icons/Maximize.tsx
+++ b/src/renderer/coremods/settings/icons/Maximize.tsx
@@ -1,0 +1,8 @@
+export default (): React.ReactElement => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+    <path
+      fill="currentColor"
+      d="M3.3 15.7a1 1 0 0 0 1.4 0L12 8.42l7.3 7.3a1 1 0 0 0 1.4-1.42l-8-8a1 1 0 0 0-1.4 0l-8 8a1 1 0 0 0 0 1.42Z"
+    />
+  </svg>
+);

--- a/src/renderer/coremods/settings/icons/Minimize.tsx
+++ b/src/renderer/coremods/settings/icons/Minimize.tsx
@@ -1,0 +1,8 @@
+export default (): React.ReactElement => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+    <path
+      fill="currentColor"
+      d="M3.3 8.3a1 1 0 0 1 1.4 0l7.3 7.29 7.3-7.3a1 1 0 1 1 1.4 1.42l-8 8a1 1 0 0 1-1.4 0l-8-8a1 1 0 0 1 0-1.42Z"
+    />
+  </svg>
+);

--- a/src/renderer/coremods/settings/icons/Pin.tsx
+++ b/src/renderer/coremods/settings/icons/Pin.tsx
@@ -1,0 +1,5 @@
+export default (): React.ReactElement => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+    <path fill="currentColor" d="M19 3H5V5H7V12H5V14H11V22H13V14H19V12H17V5H19V3Z" />
+  </svg>
+);

--- a/src/renderer/coremods/settings/icons/Popout.tsx
+++ b/src/renderer/coremods/settings/icons/Popout.tsx
@@ -1,0 +1,5 @@
+export default (): React.ReactElement => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+    <path d="M10 5V3H5.375C4.06519 3 3 4.06519 3 5.375V18.625C3 19.936 4.06519 21 5.375 21H18.625C19.936 21 21 19.936 21 18.625V14H19V19H5V5H10Z M21 2.99902H14V4.99902H17.586L9.29297 13.292L10.707 14.706L19 6.41302V9.99902H21V2.99902Z" />
+  </svg>
+);

--- a/src/renderer/coremods/settings/icons/Preview.tsx
+++ b/src/renderer/coremods/settings/icons/Preview.tsx
@@ -1,0 +1,7 @@
+// copied from discord popout
+export default (): React.ReactElement => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+    <path d="M15 2a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v6a1 1 0 1 1-2 0V4.41l-4.3 4.3a1 1 0 1 1-1.4-1.42L19.58 3H16a1 1 0 0 1-1-1Z" />
+    <path d="M5 2a3 3 0 0 0-3 3v14a3 3 0 0 0 3 3h14a3 3 0 0 0 3-3v-6a1 1 0 1 0-2 0v6a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1h6a1 1 0 1 0 0-2H5Z" />
+  </svg>
+);

--- a/src/renderer/coremods/settings/icons/Unpin.tsx
+++ b/src/renderer/coremods/settings/icons/Unpin.tsx
@@ -1,0 +1,18 @@
+export default (): React.ReactElement => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+    <g fill="none" fillRule="evenodd">
+      <path
+        fill="#f04747"
+        d="M21.47,3.39,20.14,2.05,2.53,19.66,3.86,21l4.41-4.4,1.3-1.31,1.75-1.74,3.83-3.83Z"
+      />
+    </g>
+    <g fill="none">
+      <polygon
+        points="17 11.14 16.55 11.59 14.14 14 19 14 19 12 17 12 17 11.14"
+        fill="currentColor"
+      />
+      <polygon points="16.91 3 5 3 5 5 7 5 7 12 5 12 5 14 5.91 14 16.91 3" fill="currentColor" />
+      <polygon points="12.72 15.42 11 17.14 11 22 13 22 13 15.14 12.72 15.42" fill="currentColor" />
+    </g>
+  </svg>
+);

--- a/src/renderer/coremods/settings/icons/index.ts
+++ b/src/renderer/coremods/settings/icons/index.ts
@@ -1,15 +1,29 @@
+import Close from "./Close";
 import Discord from "./Discord";
 import GitHub from "./GitHub";
 import Link from "./Link";
+import Maximize from "./Maximize";
+import Minimize from "./Minimize";
+import Pin from "./Pin";
+import Popout from "./Popout";
+import Preview from "./Preview";
 import Reload from "./Reload";
 import Settings from "./Settings";
 import Trash from "./Trash";
+import Unpin from "./Unpin";
 
 export default {
+  Close,
   Discord,
   GitHub,
   Link,
+  Maximize,
+  Minimize,
+  Pin,
+  Popout,
+  Preview,
   Reload,
   Settings,
   Trash,
+  Unpin,
 };

--- a/src/renderer/coremods/settings/pages/QuickCSS.css
+++ b/src/renderer/coremods/settings/pages/QuickCSS.css
@@ -3,15 +3,58 @@
 #replugged-quickcss-wrapper {
   height: 100%;
 }
-#replugged-quickcss-wrapper .cm-editor {
+
+.platform-win #replugged-quickcss-wrapper {
+  max-height: calc(100% - var(--custom-app-top-bar-height) - 20px);
+}
+
+#replugged-quickcss-wrapper {
   max-height: calc(100% - 20px);
+  background-color: var(--background-base-lower);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+}
+
+#replugged-quickcss-wrapper .replugged-quickcss-header h2 {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.replugged-quickcss-popout-root {
+  height: 100%;
+  width: 100%;
+}
+.replugged-quickcss-popout-root #replugged-quickcss-wrapper {
+  height: auto;
+  max-height: 100%;
+  border-radius: unset;
+}
+
+.replugged-quickcss-popout-root #replugged-quickcss-wrapper .replugged-quickcss-header {
+  -webkit-app-region: drag;
+}
+#replugged-quickcss-wrapper .replugged-quickcss-header {
+  margin: 0 var(--space-8) 0 var(--space-16);
+}
+#replugged-quickcss-wrapper .replugged-quickcss-header .replugged-quickcss-header-buttons {
+  overflow: hidden;
+  flex-flow: row-reverse;
+  flex-grow: unset !important;
+  margin: var(--space-6) 0 var(--space-6);
+  gap: 5px;
+  -webkit-app-region: no-drag;
+}
+
+#replugged-quickcss-wrapper .cm-editor {
+  max-height: calc(100% - 25px);
   background: var(--bg-overlay-2, var(--background-base-lower));
-  border: 1px solid var(--background-secondary-alt);
-  border-radius: 4px;
+  border-top: 1px solid var(--background-secondary-alt);
   outline: none !important;
 }
 .platform-win #replugged-quickcss-wrapper .cm-editor {
-  max-height: calc(100% - var(--custom-app-top-bar-height) - 20px);
+  max-height: calc(100% - var(--custom-app-top-bar-height) - 25px);
 }
 #replugged-quickcss-wrapper .cm-content {
   padding: 0px;
@@ -186,4 +229,32 @@
 #replugged-quickcss-wrapper .cm-trailingSpace,
 #replugged-quickcss-wrapper .cm-specialChar {
   color: var(--red-400);
+}
+
+#replugged-quickcss-wrapper .replugged-quickcss-popout-nagivation-container {
+  display: flex;
+  gap: 5px;
+}
+
+#replugged-quickcss-wrapper .replugged-quickcss-popout-nagivation-button {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: var(--interactive-normal);
+  border: 1px solid var(--button-outline-primary-border);
+  border-radius: var(--radius-sm);
+  min-width: 38px;
+  min-height: 38px;
+}
+#replugged-quickcss-wrapper .replugged-quickcss-popout-nagivation-button > svg {
+  width: 20px;
+  height: 20px;
+}
+
+#replugged-quickcss-wrapper .replugged-quickcss-popout-nagivation-button:hover {
+  color: var(--interactive-hover);
+}
+
+#replugged-quickcss-wrapper .replugged-quickcss-popout-nagivation-button:active {
+  color: var(--interactive-active);
 }

--- a/src/renderer/coremods/settings/pages/QuickCSS.css
+++ b/src/renderer/coremods/settings/pages/QuickCSS.css
@@ -255,6 +255,14 @@
   color: var(--interactive-hover);
 }
 
+#replugged-quickcss-wrapper
+  .replugged-quickcss-popout-nagivation-button.replugged-quickcss-close-popout:active,
+#replugged-quickcss-wrapper
+  .replugged-quickcss-popout-nagivation-button.replugged-quickcss-close-popout:hover {
+  color: var(--status-danger);
+  border-color: var(--status-danger);
+}
+
 #replugged-quickcss-wrapper .replugged-quickcss-popout-nagivation-button:active {
   color: var(--interactive-active);
 }

--- a/src/renderer/coremods/settings/pages/QuickCSS.tsx
+++ b/src/renderer/coremods/settings/pages/QuickCSS.tsx
@@ -1,8 +1,8 @@
 import { css } from "@codemirror/lang-css";
 import { EditorState } from "@codemirror/state";
 import { React, flux, fluxDispatcher, toast } from "@common";
-import { intl } from "@common/i18n";
-import { Button, Clickable, Flex, Text } from "@components";
+import { t as discordT, intl } from "@common/i18n";
+import { Button, Clickable, Flex, Text, Tooltip } from "@components";
 import { webpack } from "@replugged";
 import { EditorView, basicSetup } from "codemirror";
 import { t } from "src/renderer/modules/i18n";
@@ -133,41 +133,51 @@ const NavigationButtons = ({ windowKey }: { windowKey: string }): React.ReactEle
   const isAlwaysOnTop = flux.useStateFromStores([PopoutWindowStore], () =>
     PopoutWindowStore.getIsAlwaysOnTop(WindowKey),
   );
-
   return (
     <span className="replugged-quickcss-popout-nagivation-container">
-      <Clickable
-        onClick={() => {
-          fluxDispatcher.dispatch({
-            type: "POPOUT_WINDOW_SET_ALWAYS_ON_TOP",
-            alwaysOnTop: !isAlwaysOnTop,
-            key: windowKey,
-          });
-        }}
-        className="replugged-quickcss-popout-nagivation-button">
-        {isAlwaysOnTop ? <Icons.Unpin /> : <Icons.Pin />}
-      </Clickable>
-      <Clickable
-        onClick={() => {
-          DiscordNative.window.minimize(windowKey);
-        }}
-        className="replugged-quickcss-popout-nagivation-button">
-        <Icons.Minimize />
-      </Clickable>
-      <Clickable
-        onClick={() => {
-          DiscordNative.window.maximize(windowKey);
-        }}
-        className="replugged-quickcss-popout-nagivation-button">
-        <Icons.Maximize />
-      </Clickable>
-      <Clickable
-        onClick={() => {
-          DiscordNative.window.close(windowKey);
-        }}
-        className="replugged-quickcss-popout-nagivation-button replugged-quickcss-close-popout">
-        <Icons.Close />
-      </Clickable>
+      <Tooltip
+        text={intl.string(
+          isAlwaysOnTop ? discordT.POPOUT_REMOVE_FROM_TOP : discordT.POPOUT_STAY_ON_TOP,
+        )}>
+        <Clickable
+          onClick={() => {
+            fluxDispatcher.dispatch({
+              type: "POPOUT_WINDOW_SET_ALWAYS_ON_TOP",
+              alwaysOnTop: !isAlwaysOnTop,
+              key: windowKey,
+            });
+          }}
+          className="replugged-quickcss-popout-nagivation-button">
+          {isAlwaysOnTop ? <Icons.Unpin /> : <Icons.Pin />}
+        </Clickable>
+      </Tooltip>
+      <Tooltip text={intl.string(discordT.TITLE_BAR_MINIMIZE_WINDOW)}>
+        <Clickable
+          onClick={() => {
+            DiscordNative.window.minimize(windowKey);
+          }}
+          className="replugged-quickcss-popout-nagivation-button">
+          <Icons.Minimize />
+        </Clickable>
+      </Tooltip>
+      <Tooltip text={intl.string(discordT.TITLE_BAR_MAXIMIZE_WINDOW)}>
+        <Clickable
+          onClick={() => {
+            DiscordNative.window.maximize(windowKey);
+          }}
+          className="replugged-quickcss-popout-nagivation-button">
+          <Icons.Maximize />
+        </Clickable>
+      </Tooltip>
+      <Tooltip text={intl.string(discordT.TITLE_BAR_CLOSE_WINDOW)}>
+        <Clickable
+          onClick={() => {
+            DiscordNative.window.close(windowKey);
+          }}
+          className="replugged-quickcss-popout-nagivation-button replugged-quickcss-close-popout">
+          <Icons.Close />
+        </Clickable>
+      </Tooltip>
     </span>
   );
 };
@@ -188,27 +198,27 @@ const QuickCSSPanel = ({ isPopout }: { isPopout?: boolean }): React.ReactElement
   };
 
   const openPopout = (): void => {
-                  fluxDispatcher.dispatch({
-                    type: "POPOUT_WINDOW_OPEN",
-                    key: WindowKey,
-                    features: {
-                      frame: false,
-                      menubar: false,
-                      toolbar: false,
-                      location: false,
-                      directories: false,
-                      minWidth: 854,
-                      minHeight: 480,
-                    },
-                    render: () => (
-                      <PopoutContext withTitleBar={false} windowKey={WindowKey}>
-                        <div className="root replugged-quickcss-popout-root">
-                          <QuickCSSPanel isPopout />
-                        </div>
-                      </PopoutContext>
-                    ),
-                  });
-                }
+    fluxDispatcher.dispatch({
+      type: "POPOUT_WINDOW_OPEN",
+      key: WindowKey,
+      features: {
+        frame: false,
+        menubar: false,
+        toolbar: false,
+        location: false,
+        directories: false,
+        minWidth: 854,
+        minHeight: 480,
+      },
+      render: () => (
+        <PopoutContext withTitleBar={false} windowKey={WindowKey}>
+          <div className="root replugged-quickcss-popout-root">
+            <QuickCSSPanel isPopout />
+          </div>
+        </PopoutContext>
+      ),
+    });
+  };
 
   React.useEffect(() => {
     void window.RepluggedNative.quickCSS.get().then((val: string) => {
@@ -265,11 +275,13 @@ const QuickCSSPanel = ({ isPopout }: { isPopout?: boolean }): React.ReactElement
           <Text.H2>{intl.string(t.REPLUGGED_QUICKCSS)}</Text.H2>
           <Flex className="replugged-quickcss-header-buttons">
             {!isPopout ? (
-              <Clickable
-                onClick={openPopout}
-                className="replugged-quickcss-popout-nagivation-button">
-                <Icons.Popout />
-              </Clickable>
+              <Tooltip text={intl.string(discordT.POPOUT_PLAYER)}>
+                <Clickable
+                  onClick={openPopout}
+                  className="replugged-quickcss-popout-nagivation-button">
+                  <Icons.Popout />
+                </Clickable>
+              </Tooltip>
             ) : (
               <NavigationButtons windowKey={WindowKey} />
             )}

--- a/src/renderer/coremods/settings/pages/QuickCSS.tsx
+++ b/src/renderer/coremods/settings/pages/QuickCSS.tsx
@@ -298,7 +298,7 @@ export const QuickCSS = (): React.ReactElement => {
   return isPopoutOpen ? (
     <>
       <Flex align={Flex.Align.CENTER} justify={Flex.Justify.CENTER} style={{ height: "100%" }}>
-        <Text.H3>You&apos;ve popped out the editor to another window</Text.H3>
+        <Text.H3>{intl.string(t.REPLUGGED_QUICKCSS_EDITOR_POPPED_OUT)}</Text.H3>
       </Flex>
     </>
   ) : (

--- a/src/renderer/coremods/settings/pages/QuickCSS.tsx
+++ b/src/renderer/coremods/settings/pages/QuickCSS.tsx
@@ -165,7 +165,7 @@ const NavigationButtons = ({ windowKey }: { windowKey: string }): React.ReactEle
         onClick={() => {
           DiscordNative.window.close(windowKey);
         }}
-        className="replugged-quickcss-popout-nagivation-button">
+        className="replugged-quickcss-popout-nagivation-button replugged-quickcss-close-popout">
         <Icons.Close />
       </Clickable>
     </span>


### PR DESCRIPTION
- This can be merged instead of https://github.com/replugged-org/replugged/pull/652
- Implemented Popout
- Stops all of Discord's keybinds when active
- Removed the CSS hack for stickers

Preview In-App:
<img width="648" height="1001" alt="image" src="https://github.com/user-attachments/assets/1b053e6d-cb2a-488c-af03-4aab64a03d7b" />

Preview Popped-Out: 
<img width="1314" height="968" alt="image" src="https://github.com/user-attachments/assets/74e2b4c0-e695-47a2-9105-5468a05d3b18" />
 