### PR TITLE
Patch Tray Context Menu

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,9 +1,13 @@
 import electron, {
   type BrowserWindowConstructorOptions,
+  Menu,
+  type MenuItemConstructorOptions,
   app,
+  dialog,
   net,
   protocol,
   session,
+  shell,
 } from "electron";
 import { dirname, join } from "path";
 import { CONFIG_PATHS } from "src/util.mjs";
@@ -11,6 +15,7 @@ import type { PackageJson } from "type-fest";
 import { pathToFileURL } from "url";
 import type { RepluggedWebContents } from "../types";
 import { getSetting } from "./ipc/settings";
+import { getRepluggedVersion, store as getStoreAddon, installAddon } from "./ipc/installer";
 
 const electronPath = require.resolve("electron");
 const discordPath = join(dirname(require.main!.filename), "..", "app.orig.asar");
@@ -101,6 +106,108 @@ originalRegisterSchemesAsPrivileged([repluggedProtocol]);
 protocol.registerSchemesAsPrivileged = (customSchemes: Electron.CustomScheme[]) => {
   const combinedSchemes = [repluggedProtocol, ...customSchemes];
   originalRegisterSchemesAsPrivileged(combinedSchemes);
+};
+
+// Monkey patch to add our menu items into the tray context menu.
+const defaultBuildFromTemplate = Menu.buildFromTemplate.bind(Menu);
+const currentVersion = getRepluggedVersion();
+
+Menu.buildFromTemplate = (items: MenuItemConstructorOptions[]) => {
+  // Make sure first item is Discord and so that its not in popout or any other menu
+  if (items[0]?.label !== "Discord") return defaultBuildFromTemplate(items);
+  if (!items.find((e) => e.label === "Replugged"))
+    items.splice(
+      // Quit + seperator
+      -2,
+      0,
+      { type: "separator" },
+      {
+        label: "Replugged",
+        submenu: [
+          {
+            label: "Toggle DevTools",
+            role: "toggleDevTools",
+          },
+          {
+            // Should we just do enabled: currentVersion !== "dev" instead of dialog??
+            label: "Update Replugged",
+            click: async (_) => {
+              if (currentVersion === "dev") {
+                void dialog.showMessageBox({
+                  type: "info",
+                  title: "Developer Mode",
+                  message:
+                    "You are currently running Replugged in developer mode and Replugged will not be able to update itself.",
+                  buttons: ["Ok"],
+                });
+                return;
+              }
+              const repluggedInfo = await getStoreAddon("dev.replugged.Replugged");
+
+              if (!repluggedInfo.success) {
+                void dialog.showMessageBox({
+                  type: "error",
+                  title: "Failed Check",
+                  message: "Failed while checking for updates. Check logs for more info!",
+                  buttons: ["Close"],
+                });
+                console.error(repluggedInfo.error);
+                return;
+              }
+              const newVersion = repluggedInfo.manifest.version;
+              if (currentVersion === newVersion) {
+                void dialog.showMessageBox({
+                  type: "info",
+                  title: "Up to date",
+                  message: "Replugged is already up to date.",
+                  buttons: ["Ok"],
+                });
+                return;
+              }
+              const installed = await installAddon(
+                "replugged",
+                "replugged.asar",
+                repluggedInfo.url,
+                true,
+                newVersion,
+              );
+              if (!installed.success) {
+                void dialog.showMessageBox({
+                  type: "error",
+                  title: "Failed Install",
+                  message: "Failed while installing updates. Check logs for more info!",
+                  buttons: ["Close"],
+                });
+                console.error(installed.error);
+                return;
+              }
+
+              await dialog.showMessageBox({
+                type: "info",
+                title: "Successfully Updated",
+                message:
+                  process.platform === "linux"
+                    ? "Relugged updated but we can't relaunch automatically due to an bug on electron linux, discord will close now!"
+                    : "Replugged update and will relaunch discord now to take effects!",
+                buttons: ["Ok"],
+              });
+              app.relaunch();
+              app.quit();
+            },
+          },
+          {
+            label: "Contributors",
+            click: () => shell.openExternal("https://replugged.dev/contributors"),
+          },
+          {
+            enabled: false,
+            label: `Version: ${currentVersion === "dev" ? "" : "v"}${currentVersion}`,
+          },
+        ],
+      },
+    );
+
+  return defaultBuildFromTemplate(items);
 };
 
 // Copied from old codebase


### PR DESCRIPTION
Adds the following options to tray menu:
- Toggle Devtools (Closes/Open Devtools on the focused window)
- Update Replugged (Updates just replugged to latest version)
- Contributors (opens https://replugged.dev/contributors)
- Version (Shows the version info)

TODO:
- i18n for the tray menu. I don't know how to do it from the backend. **HELP NEEDED**

CurrentPreview: 
<img width="234" height="318" alt="image" src="https://github.com/user-attachments/assets/a83babae-ff0b-4cd8-a698-a4b97cf70686" />
