### PR TITLE
feat: RPC Refactor

### DIFF
--- a/src/renderer/apis/rpc.ts
+++ b/src/renderer/apis/rpc.ts
@@ -1,0 +1,98 @@
+import type { Jsonifiable } from "type-fest";
+
+interface RPCData {
+  args: Record<string, Jsonifiable | undefined>;
+  cmd: string;
+}
+
+interface RPCCommand {
+  scope?:
+    | string
+    | {
+        $any: string[];
+      };
+  handler: (
+    data: RPCData,
+  ) =>
+    | Record<string, Jsonifiable | undefined>
+    | Promise<Record<string, Jsonifiable | undefined>>
+    | void
+    | Promise<void>;
+}
+
+type Commands = Record<string, RPCCommand>;
+
+class RpcAPI {
+  #commandMap = new Map<string, RPCCommand>();
+  /**
+   * internal
+   * @param name Command name
+   * @returns Boolean
+   */
+  #checkName(name: string): void {
+    if (!name.startsWith("REPLUGGED_"))
+      throw new Error("RPC command name must start with REPLUGGED_");
+  }
+
+  /**
+   * Function to Register RPC Commands
+   * @param name Command name
+   * @param command Command handler
+   * @returns Unregister function
+   */
+  public registerRPCCommand(name: string, command: RPCCommand): () => void {
+    this.#checkName(name);
+    if (this.#commandMap.has(name)) throw new Error("RPC command already exists");
+    this.#commandMap.set(name, command);
+    return () => {
+      this.#commandMap.delete(name);
+    };
+  }
+
+  /**
+   * Function to Unregister RPC Commands
+   * @param name Command name
+   */
+  public unregisterRPCCommand(name: string): void {
+    this.#checkName(name);
+    this.#commandMap.delete(name);
+  }
+
+  /**
+   * internal
+   * @param commands Original Discord's commands object
+   * @returns RPC Commands Proxy
+   */
+  public _getCommands(commands: Commands): Commands {
+    return new Proxy(commands, {
+      get: (target, prop: string) => {
+        if (prop in target) {
+          return Reflect.get(target, prop);
+        }
+        return this.#commandMap.get(prop);
+      },
+      set: (target, prop, value) => {
+        return Reflect.set(target, prop, value);
+      },
+      deleteProperty: (target, prop) => {
+        return Reflect.deleteProperty(target, prop);
+      },
+      ownKeys: (target) => {
+        return [...Reflect.ownKeys(target), ...this.#commandMap.keys()];
+      },
+      getOwnPropertyDescriptor: (target, prop: string) => {
+        if (prop in target) {
+          return Object.getOwnPropertyDescriptor(target, prop);
+        }
+        return {
+          configurable: true,
+          enumerable: true,
+          writable: false,
+          value: this.#commandMap.get(prop),
+        };
+      },
+    });
+  }
+}
+
+export default new RpcAPI();

--- a/src/renderer/coremods/installer/index.tsx
+++ b/src/renderer/coremods/installer/index.tsx
@@ -6,7 +6,7 @@ import { plugins } from "src/renderer/managers/plugins";
 import { themes } from "src/renderer/managers/themes";
 import { filters, getFunctionKeyBySource, waitForModule } from "src/renderer/modules/webpack";
 import type { ObjectExports } from "src/types";
-import { registerRPCCommand } from "../rpc";
+import rpc from "../../apis/rpc";
 import { generalSettings } from "../settings/pages";
 import AddonEmbed from "./AddonEmbed";
 import { loadCommands } from "./commands";
@@ -35,7 +35,7 @@ if (window.RepluggedNative.getVersion() === "dev") {
 }
 
 function injectRpc(): void {
-  const uninjectInstall = registerRPCCommand("REPLUGGED_INSTALL", {
+  const uninjectInstall = rpc.registerRPCCommand("REPLUGGED_INSTALL", {
     scope: {
       $any: scopes,
     },
@@ -59,7 +59,7 @@ function injectRpc(): void {
     },
   });
 
-  const uninjectList = registerRPCCommand("REPLUGGED_LIST_ADDONS", {
+  const uninjectList = rpc.registerRPCCommand("REPLUGGED_LIST_ADDONS", {
     scope: {
       $any: scopes,
     },

--- a/src/renderer/coremods/rpc/plaintextPatches.ts
+++ b/src/renderer/coremods/rpc/plaintextPatches.ts
@@ -1,0 +1,13 @@
+import type { PlaintextPatch } from "src/types";
+
+export default [
+  {
+    find: "RPC_STORE_WAIT",
+    replacements: [
+      {
+        match: /this,"commands",{}/,
+        replace: () => `this,"commands",replugged.rpc?._getCommands({}),`,
+      },
+    ],
+  },
+] as PlaintextPatch[];

--- a/src/renderer/coremods/watcher/index.ts
+++ b/src/renderer/coremods/watcher/index.ts
@@ -2,14 +2,14 @@ import { intl } from "@common/i18n";
 import toast from "@common/toast";
 import { Logger, plugins, themes } from "@replugged";
 import { t } from "src/renderer/modules/i18n";
-import { registerRPCCommand } from "../rpc";
+import rpc from "../../apis/rpc";
 
 const logger = Logger.coremod("Watcher");
 
 const uninjectors: Array<() => void> = [];
 
 export function start(): void {
-  const uninjectRpc = registerRPCCommand("REPLUGGED_ADDON_WATCHER", {
+  const uninjectRpc = rpc.registerRPCCommand("REPLUGGED_ADDON_WATCHER", {
     scope: "REPLUGGED_LOCAL",
     handler: async (data) => {
       const { id } = data.args;

--- a/src/renderer/managers/coremods.ts
+++ b/src/renderer/managers/coremods.ts
@@ -13,6 +13,7 @@ import noTrackPlaintext from "../coremods/noTrack/plaintextPatches";
 import noXSSDefensesPlaintext from "../coremods/noXSSDefenses/plaintextPatches";
 import popoutThemingPlaintext from "../coremods/popoutTheming/plaintextPatches";
 import reactErrorDecoderPlaintext from "../coremods/reactErrorDecoder/plaintextPatches";
+import rpcPlaintext from "../coremods/rpc/plaintextPatches";
 import settingsPlaintext from "../coremods/settings/plaintextPatches";
 import titleBarPlaintext from "../coremods/titleBar/plaintextPatches";
 
@@ -95,6 +96,7 @@ export function runPlaintextPatches(): void {
     { patch: noTrackPlaintext, name: "replugged.coremod.noTrack" },
     { patch: popoutThemingPlaintext, name: "replugged.coremod.popoutTheming" },
     { patch: reactErrorDecoderPlaintext, name: "replugged.coremod.reactErrorDecoder" },
+    { patch: rpcPlaintext, name: "replugged.coremod.rpc" },
     { patch: settingsPlaintext, name: "replugged.coremod.settings" },
     { patch: titleBarPlaintext, name: "replugged.coremod.titleBar" },
   ].forEach(({ patch, name }) => patchPlaintext(patch, name));

--- a/src/renderer/replugged.ts
+++ b/src/renderer/replugged.ts
@@ -22,6 +22,7 @@ export * as components from "./modules/components";
 export * as i18n from "./modules/i18n";
 
 export { default as notices } from "./apis/notices";
+export { default as rpc } from "./apis/rpc";
 export * as settings from "./apis/settings";
 
 /**


### PR DESCRIPTION

- Move Handler for RPC Commands (Register/Unregister) into APIs
- Instead of modifying the original object
- Switched to Map for Replugged's RPC Commands
- Switched to plaintext patch to add replugged's commands
- Made RPC API a class
- Minor Refracotr moving injectRPC into start directly 