### PR TITLE
Tabs in Updater

### DIFF
--- a/i18n/en-US.messages.d.ts
+++ b/i18n/en-US.messages.d.ts
@@ -1408,7 +1408,7 @@ export declare const messages: {
    * 
    * ### Problems
    * 
-   * Missing translations: `bg`, `cs`, `da`, `de`, `el`, `en-GB`, `es-419`, `es-ES`, `fi`, `fr`, `hi`, `hr`, `hu`, `it`, `ja`, `ko`, `lt`, `nl`, `no`, `pl`, `pt-BR`, `ro`, `ru`, `sv-SE`, `th`, `tr`, `uk`, `vi`, `zh-CN`, `zh-TW`
+   * Missing translations: `bg`, `cs`, `da`, `de`, `el`, `en-GB`, `es-419`, `es-ES`, `fi`, `fr`, `hi`, `hr`, `hu`, `it`, `ja`, `ko`, `lt`, `no`, `pl`, `pt-BR`, `ro`, `ru`, `sv-SE`, `th`, `tr`, `uk`, `vi`, `zh-CN`, `zh-TW`
    */
   'REPLUGGED_SETTINGS_DEVELOPMENT_TOOLS': TypedIntlMessageGetter<{}>,
   /**
@@ -1824,7 +1824,7 @@ export declare const messages: {
    * 
    * ### Problems
    * 
-   * Missing translations: `bg`, `cs`, `da`, `de`, `el`, `en-GB`, `es-419`, `es-ES`, `fi`, `fr`, `hi`, `hr`, `hu`, `it`, `ja`, `ko`, `lt`, `nl`, `no`, `pl`, `pt-BR`, `ro`, `ru`, `sv-SE`, `th`, `tr`, `uk`, `vi`, `zh-CN`, `zh-TW`
+   * Missing translations: `bg`, `cs`, `da`, `de`, `el`, `en-GB`, `es-419`, `es-ES`, `fi`, `fr`, `hi`, `hr`, `hu`, `it`, `ja`, `ko`, `lt`, `no`, `pl`, `pt-BR`, `ro`, `ru`, `sv-SE`, `th`, `tr`, `uk`, `vi`, `zh-CN`, `zh-TW`
    */
   'REPLUGGED_SETTINGS_WIN_UPDATER': TypedIntlMessageGetter<{}>,
   /**
@@ -1837,7 +1837,7 @@ export declare const messages: {
    * 
    * ### Problems
    * 
-   * Missing translations: `bg`, `cs`, `da`, `de`, `el`, `en-GB`, `es-419`, `es-ES`, `fi`, `fr`, `hi`, `hr`, `hu`, `it`, `ja`, `ko`, `lt`, `nl`, `no`, `pl`, `pt-BR`, `ro`, `ru`, `sv-SE`, `th`, `tr`, `uk`, `vi`, `zh-CN`, `zh-TW`
+   * Missing translations: `bg`, `cs`, `da`, `de`, `el`, `en-GB`, `es-419`, `es-ES`, `fi`, `fr`, `hi`, `hr`, `hu`, `it`, `ja`, `ko`, `lt`, `no`, `pl`, `pt-BR`, `ro`, `ru`, `sv-SE`, `th`, `tr`, `uk`, `vi`, `zh-CN`, `zh-TW`
    */
   'REPLUGGED_SETTINGS_WIN_UPDATER_DESC': TypedIntlMessageGetter<{}>,
   /**
@@ -2218,6 +2218,19 @@ export declare const messages: {
    */
   'REPLUGGED_UPDATES_CHECK': TypedIntlMessageGetter<{}>,
   /**
+   * Key: `eFNZS0`
+   * 
+   * ### Definition
+   * ```text
+   * Configuration
+   * ```
+   * 
+   * ### Problems
+   * 
+   * Missing translations: `bg`, `cs`, `da`, `de`, `el`, `en-GB`, `es-419`, `es-ES`, `fi`, `fr`, `hi`, `hr`, `hu`, `it`, `ja`, `ko`, `lt`, `nl`, `no`, `pl`, `pt-BR`, `ro`, `ru`, `sv-SE`, `th`, `tr`, `uk`, `vi`, `zh-CN`, `zh-TW`
+   */
+  'REPLUGGED_UPDATES_CONFIGURATION': TypedIntlMessageGetter<{}>,
+  /**
    * Key: `DCXylp`
    * 
    * ### Definition
@@ -2594,6 +2607,19 @@ export declare const messages: {
    * Missing translations: `bg`, `da`, `el`, `es-419`, `hi`, `hr`, `lt`, `no`, `ro`, `th`
    */
   'REPLUGGED_UPDATES_UPDATER': TypedIntlMessageGetter<{}>,
+  /**
+   * Key: `s4evKC`
+   * 
+   * ### Definition
+   * ```text
+   * Updates
+   * ```
+   * 
+   * ### Problems
+   * 
+   * Missing translations: `bg`, `cs`, `da`, `de`, `el`, `en-GB`, `es-419`, `es-ES`, `fi`, `fr`, `hi`, `hr`, `hu`, `it`, `ja`, `ko`, `lt`, `nl`, `no`, `pl`, `pt-BR`, `ro`, `ru`, `sv-SE`, `th`, `tr`, `uk`, `vi`, `zh-CN`, `zh-TW`
+   */
+  'REPLUGGED_UPDATES_UPDATES': TypedIntlMessageGetter<{}>,
   /**
    * Key: `uMS9c3`
    * 

--- a/i18n/en-US.messages.js
+++ b/i18n/en-US.messages.js
@@ -117,6 +117,8 @@ export default defineMessages({
   "REPLUGGED_UPDATES_UPDATING": "Updating Replugged…",
   "REPLUGGED_UPDATES_UPDATING_ITEM": "Updating…",
   "REPLUGGED_UPDATES_UP_TO_DATE": "Everything is up to date.",
+  "REPLUGGED_UPDATES_UPDATES": "Updates",
+  "REPLUGGED_UPDATES_CONFIGURATION": "Configuration",
   "REPLUGGED_PLUGIN_EMBED_VIEW_REPO": "View Repo",
   "REPLUGGED_ADDON_DELETE": "Delete {type}",
   "REPLUGGED_ADDON_PAGE_OPEN": "Open {type} Page",

--- a/src/renderer/coremods/settings/pages/Updater.css
+++ b/src/renderer/coremods/settings/pages/Updater.css
@@ -4,3 +4,7 @@
   padding: var(--space-16);
   border-radius: var(--radius-sm);
 }
+
+.replugged-updater-tabBarPanel {
+  margin-top: var(--space-24);
+}


### PR DESCRIPTION
- Added tabs in updater
- Separated settings for updater and the updates themselves
- Updates tab is selected by default
- Added two new strings for tab titles `REPLUGGED_UPDATES_UPDATES` and `REPLUGGED_UPDATES_CONFIGURATION`
- Added css for updater tab panel