### PR TITLE
Setting Search 2.0

### DIFF
--- a/src/renderer/coremods/settings/index.tsx
+++ b/src/renderer/coremods/settings/index.tsx
@@ -23,7 +23,7 @@ import {
   useAddonPanelTitle,
 } from "./pages";
 
-import { PageTypes, usePageSearchTerms } from "./searchTerms"
+import { PageTypes, usePageSearchTerms } from "./searchTerms";
 
 export function _renderVersionInfo(): React.ReactElement {
   return (
@@ -51,14 +51,14 @@ export function start(): void {
         icon: RepluggedIcon,
         useTitle: () => intl.string(discordT.SETTINGS_GENERAL),
         render: General,
-        useSearchTerms: usePageSearchTerms(PageTypes.General)
+        useSearchTerms: usePageSearchTerms(PageTypes.General),
       }),
       createCustomSettingsPanel("quickcss", {
         icon: MagicWandIcon,
         useTitle: () => intl.string(t.REPLUGGED_QUICKCSS),
         render: QuickCSS,
         usePredicate: () => generalSettings.useValue("quickCSS"),
-        useSearchTerms: usePageSearchTerms(PageTypes.QuickCSS)
+        useSearchTerms: usePageSearchTerms(PageTypes.QuickCSS),
       }),
       createCustomSettingsPanel("plugins", {
         icon: PuzzlePieceIcon,
@@ -66,7 +66,7 @@ export function start(): void {
         usePanelTitle: () => useAddonPanelTitle(AddonType.Plugin),
         getLegacySearchKey: () => intl.string(t.REPLUGGED_PLUGINS),
         render: Plugins,
-        useSearchTerms: usePageSearchTerms(PageTypes.Addon, AddonType.Plugin)
+        useSearchTerms: usePageSearchTerms(PageTypes.Addon, AddonType.Plugin),
       }),
       createCustomSettingsPanel("themes", {
         icon: PaintbrushThinIcon,
@@ -74,13 +74,13 @@ export function start(): void {
         usePanelTitle: () => useAddonPanelTitle(AddonType.Theme),
         getLegacySearchKey: () => intl.string(t.REPLUGGED_THEMES),
         render: Themes,
-        useSearchTerms: usePageSearchTerms(PageTypes.Addon, AddonType.Theme)
+        useSearchTerms: usePageSearchTerms(PageTypes.Addon, AddonType.Theme),
       }),
       createCustomSettingsPanel("updater", {
         icon: RefreshIcon,
         useTitle: () => intl.string(t.REPLUGGED_UPDATES_UPDATER),
         render: Updater,
-        useSearchTerms: usePageSearchTerms(PageTypes.Updater)
+        useSearchTerms: usePageSearchTerms(PageTypes.Updater),
       }),
     ],
   });

--- a/src/renderer/coremods/settings/index.tsx
+++ b/src/renderer/coremods/settings/index.tsx
@@ -23,6 +23,8 @@ import {
   useAddonPanelTitle,
 } from "./pages";
 
+import { PageTypes, usePageSearchTerms } from "./searchTerms"
+
 export function _renderVersionInfo(): React.ReactElement {
   return (
     <Text variant="text-xxs/normal" color="text-muted" tag="span">
@@ -49,12 +51,14 @@ export function start(): void {
         icon: RepluggedIcon,
         useTitle: () => intl.string(discordT.SETTINGS_GENERAL),
         render: General,
+        useSearchTerms: usePageSearchTerms(PageTypes.General)
       }),
       createCustomSettingsPanel("quickcss", {
         icon: MagicWandIcon,
         useTitle: () => intl.string(t.REPLUGGED_QUICKCSS),
         render: QuickCSS,
         usePredicate: () => generalSettings.useValue("quickCSS"),
+        useSearchTerms: usePageSearchTerms(PageTypes.QuickCSS)
       }),
       createCustomSettingsPanel("plugins", {
         icon: PuzzlePieceIcon,
@@ -62,6 +66,7 @@ export function start(): void {
         usePanelTitle: () => useAddonPanelTitle(AddonType.Plugin),
         getLegacySearchKey: () => intl.string(t.REPLUGGED_PLUGINS),
         render: Plugins,
+        useSearchTerms: usePageSearchTerms(PageTypes.Addon, AddonType.Plugin)
       }),
       createCustomSettingsPanel("themes", {
         icon: PaintbrushThinIcon,
@@ -69,11 +74,13 @@ export function start(): void {
         usePanelTitle: () => useAddonPanelTitle(AddonType.Theme),
         getLegacySearchKey: () => intl.string(t.REPLUGGED_THEMES),
         render: Themes,
+        useSearchTerms: usePageSearchTerms(PageTypes.Addon, AddonType.Theme)
       }),
       createCustomSettingsPanel("updater", {
         icon: RefreshIcon,
         useTitle: () => intl.string(t.REPLUGGED_UPDATES_UPDATER),
         render: Updater,
+        useSearchTerms: usePageSearchTerms(PageTypes.Updater)
       }),
     ],
   });

--- a/src/renderer/coremods/settings/lib.tsx
+++ b/src/renderer/coremods/settings/lib.tsx
@@ -53,7 +53,7 @@ export function removeSettingNode(key: string): void {
 }
 
 type CustomSettingsPaneOptions = Required<Pick<SidebarItemNode, "icon" | "useTitle">> &
-  Pick<SidebarItemNode, "usePredicate" | "getLegacySearchKey"> & {
+  Pick<SidebarItemNode, "usePredicate" | "getLegacySearchKey" | "useSearchTerms"> & {
     usePanelTitle?: PanelNode["useTitle"];
     render: React.ElementType;
   };
@@ -73,15 +73,18 @@ export function createCustomSettingsPanel(
     usePredicate,
     getLegacySearchKey,
     usePanelTitle,
+    useSearchTerms,
   }: CustomSettingsPaneOptions,
 ): ReturnType<typeof createSidebarItem> {
   return createSidebarItem(`replugged_${key}_sidebar_item`, {
     icon,
     useTitle,
+
     getLegacySearchKey: getLegacySearchKey ?? useTitle,
     ...(usePredicate && { usePredicate }),
     buildLayout: () => [
       createPanel(`replugged_${key}_panel`, {
+        useSearchTerms,
         useTitle: usePanelTitle ?? useTitle,
         StronglyDiscouragedCustomComponent: () => (
           <ErrorBoundary>

--- a/src/renderer/coremods/settings/lib.tsx
+++ b/src/renderer/coremods/settings/lib.tsx
@@ -79,7 +79,6 @@ export function createCustomSettingsPanel(
   return createSidebarItem(`replugged_${key}_sidebar_item`, {
     icon,
     useTitle,
-
     getLegacySearchKey: getLegacySearchKey ?? useTitle,
     ...(usePredicate && { usePredicate }),
     buildLayout: () => [

--- a/src/renderer/coremods/settings/pages/Addons.tsx
+++ b/src/renderer/coremods/settings/pages/Addons.tsx
@@ -25,7 +25,7 @@ import type { RepluggedPlugin, RepluggedTheme } from "src/types";
 import type { AnyAddonManifest, Author } from "src/types/addon";
 import { UserSettingsForm } from "..";
 import { ClydeIcon, GitHubIcon, LinkIcon, RefreshIcon, SettingsIcon, TrashIcon } from "../icons";
-import { SearchStore } from "../searchTerms"
+import { SearchStore } from "../searchTerms";
 
 import "./Addons.css";
 
@@ -536,7 +536,7 @@ export function useAddonPanelTitle(type: AddonType): string {
 }
 
 export const Addons = (type: AddonType): React.ReactElement => {
-  const settingQuery = SearchStore.useField("query")
+  const settingQuery = SearchStore.useField("query");
   const [disabled, setDisabled] = React.useState<Set<string>>(new Set());
   const [search, setSearch] = React.useState("");
   const [list, setList] = React.useState<Array<RepluggedPlugin | RepluggedTheme> | null>();
@@ -660,8 +660,8 @@ export const Addons = (type: AddonType): React.ReactElement => {
             {unfilteredCount
               ? intl.format(t.REPLUGGED_NO_ADDON_RESULTS, { type: label(type, { plural: true }) })
               : intl.format(t.REPLUGGED_NO_ADDONS_INSTALLED, {
-                type: label(type, { plural: true }),
-              })}
+                  type: label(type, { plural: true }),
+                })}
           </Text>
         ) : null
       ) : (

--- a/src/renderer/coremods/settings/pages/Addons.tsx
+++ b/src/renderer/coremods/settings/pages/Addons.tsx
@@ -25,6 +25,7 @@ import type { RepluggedPlugin, RepluggedTheme } from "src/types";
 import type { AnyAddonManifest, Author } from "src/types/addon";
 import { UserSettingsForm } from "..";
 import { ClydeIcon, GitHubIcon, LinkIcon, RefreshIcon, SettingsIcon, TrashIcon } from "../icons";
+import { SearchStore } from "../searchTerms"
 
 import "./Addons.css";
 
@@ -535,6 +536,7 @@ export function useAddonPanelTitle(type: AddonType): string {
 }
 
 export const Addons = (type: AddonType): React.ReactElement => {
+  const settingQuery = SearchStore.useField("query")
   const [disabled, setDisabled] = React.useState<Set<string>>(new Set());
   const [search, setSearch] = React.useState("");
   const [list, setList] = React.useState<Array<RepluggedPlugin | RepluggedTheme> | null>();
@@ -556,7 +558,7 @@ export const Addons = (type: AddonType): React.ReactElement => {
             ...[x.manifest.author].flat().map(Object.values).flat(),
           ].map((x) => x.toLowerCase());
 
-          return props.some((x) => x.includes(search.toLowerCase()));
+          return props.some((x) => x.includes((search || settingQuery).toLowerCase()));
         })
         .sort((a, b) => a.manifest.name.toLowerCase().localeCompare(b.manifest.name.toLowerCase())),
     );
@@ -564,7 +566,7 @@ export const Addons = (type: AddonType): React.ReactElement => {
     setDisabled(new Set(getManager(type).getDisabled()));
   }
 
-  React.useEffect(refreshList, [search, type]);
+  React.useEffect(refreshList, [settingQuery, search, type]);
 
   return (
     <UserSettingsForm
@@ -627,7 +629,7 @@ export const Addons = (type: AddonType): React.ReactElement => {
           </Button>
         </Stack>
       )}
-      {section === `rp_${type}` && unfilteredCount ? (
+      {section === `rp_${type}` && unfilteredCount && (!settingQuery || search) ? (
         <SearchBar
           query={search}
           onChange={(query) => setSearch(query)}
@@ -658,8 +660,8 @@ export const Addons = (type: AddonType): React.ReactElement => {
             {unfilteredCount
               ? intl.format(t.REPLUGGED_NO_ADDON_RESULTS, { type: label(type, { plural: true }) })
               : intl.format(t.REPLUGGED_NO_ADDONS_INSTALLED, {
-                  type: label(type, { plural: true }),
-                })}
+                type: label(type, { plural: true }),
+              })}
           </Text>
         ) : null
       ) : (

--- a/src/renderer/coremods/settings/searchTerms.ts
+++ b/src/renderer/coremods/settings/searchTerms.ts
@@ -1,0 +1,114 @@
+import { plugins, themes, webpack } from "@replugged";
+import { t as discordT, intl } from "@common/i18n";
+import { t } from "src/renderer/modules/i18n";
+import type { ValueOf } from "type-fest";
+
+import { AddonType } from "./pages";
+
+export interface SearchState {
+  query: string;
+  isActive: boolean;
+  isFocused: boolean;
+  selected: string | null;
+}
+
+type Selector<S, T> = (state: S) => T;
+
+export interface SearchStore {
+  getField<K extends keyof SearchState>(key: K): SearchState[K];
+  getState(): SearchState;
+  getState<T>(selector: Selector<SearchState, T>): T;
+  setState(
+    next: Partial<SearchState> | ((prev: SearchState) => Partial<SearchState> | SearchState),
+  ): void;
+  resetState(): void;
+  subscribe<T = SearchState>(
+    listener: (value: T) => void,
+    selector?: Selector<SearchState, T>,
+    equalityFn?: (a: T, b: T) => boolean,
+  ): () => void;
+  useField<K extends keyof SearchState>(key: K): SearchState[K];
+  useState(): SearchState;
+  useState<T>(selector: Selector<SearchState, T>): T;
+}
+
+export const SearchStore: SearchStore = await webpack.waitForModule(
+  webpack.filters.bySource('query:"",isActive:!1,isFocused'),
+  { timeout: 10000 },
+);
+
+export const PageTypes = {
+  Addon: "addon",
+  General: "general",
+  QuickCSS: "quick-css",
+  Updater: "updater",
+} as const;
+
+export function usePageSearchTerms(
+  page: ValueOf<typeof PageTypes>,
+  addonType?: AddonType,
+): () => string[] {
+  if (page === PageTypes.Addon) {
+    const type =
+      addonType === AddonType.Theme
+        ? intl.string(t.REPLUGGED_THEMES)
+        : intl.string(t.REPLUGGED_PLUGINS);
+    const addonsMap = addonType === AddonType.Theme ? themes.themes : plugins.plugins;
+
+    return (): string[] =>
+      [...addonsMap.values()].reduce(
+        (acc: string[], x) => {
+          acc.push(
+            x.manifest.name,
+            x.manifest.id,
+            x.manifest.description,
+            ...([x.manifest.author].flat().map(Object.values).flat() as string[]),
+          );
+          return acc;
+        },
+        [
+          type,
+          intl.formatToPlainString(t.REPLUGGED_ADDON_BROWSE, {
+            type,
+          }),
+          intl.formatToPlainString(t.REPLUGGED_ADDONS_LOAD_MISSING, {
+            type,
+          }),
+          intl.formatToPlainString(t.REPLUGGED_ADDONS_FOLDER_OPEN, {
+            type,
+          }),
+        ],
+      );
+  }
+  if (page === PageTypes.QuickCSS)
+    return () => [intl.string(t.REPLUGGED_QUICKCSS), intl.string(t.REPLUGGED_QUICKCSS_FOLDER_OPEN)];
+  if (page === PageTypes.Updater)
+    return () => [
+      intl.string(t.REPLUGGED_UPDATES_UPDATE_ALL),
+      intl.string(t.REPLUGGED_UPDATES_CHECK),
+      intl.string(discordT.UPDATE),
+      intl.string(t.REPLUGGED_UPDATES_UPDATER),
+      intl.string(t.REPLUGGED_UPDATES_OPTS_AUTO),
+      intl.string(t.REPLUGGED_UPDATES_OPTS_INTERVAL),
+      intl.string(t.REPLUGGED_UPDATES_UPDATER),
+    ];
+
+  return () => [
+    intl.string(discordT.SETTINGS_GENERAL),
+    intl.string(t.REPLUGGED_SETTINGS_BADGES),
+    intl.string(t.REPLUGGED_SETTINGS_ADDON_EMBEDS),
+    intl.string(t.REPLUGGED_SETTINGS_QUICKCSS_ENABLE),
+    intl.string(t.REPLUGGED_SETTINGS_QUICKCSS_AUTO_APPLY),
+    intl.string(t.REPLUGGED_SETTINGS_DISABLE_MIN_SIZE),
+    intl.string(t.REPLUGGED_SETTINGS_CUSTOM_TITLE_BAR),
+    intl.string(t.REPLUGGED_SETTINGS_TRANSPARENT),
+    intl.string(t.REPLUGGED_SETTINGS_TRANSPARENCY_BG_MATERIAL),
+    intl.string(t.REPLUGGED_SETTINGS_TRANSPARENCY_VIBRANCY),
+    intl.string(t.REPLUGGED_SETTINGS_DISCORD_EXPERIMENTS),
+    intl.string(t.REPLUGGED_SETTINGS_DISCORD_DEVTOOLS),
+    intl.string(t.REPLUGGED_SETTINGS_REACT_DEVTOOLS),
+    intl.string(t.REPLUGGED_SETTINGS_KEEP_TOKEN),
+    intl.string(t.REPLUGGED_SETTINGS_WIN_UPDATER),
+    intl.string(t.REPLUGGED_SETTINGS_BACKEND),
+  ];
+}


### PR DESCRIPTION
- Shows Replugged's Section when search some setting inside it.
- Hides Addon's Search Bar when searching and shows addon directly if searched for it

TODO?:
- Hide Sections in settings based on search query. Eg - when searching for quick css keep only quick css settings in general . 